### PR TITLE
Add support for mod_auth_pam

### DIFF
--- a/nginx-build-pagespeed.sh
+++ b/nginx-build-pagespeed.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-apt-get install -y build-essential libtool automake autoconf zlib1g-dev libpcre3-dev libgd-dev libssl-dev libxslt1-dev libxml2-dev libgeoip-dev libgoogle-perftools-dev libperl-dev
+apt-get install -y build-essential libtool automake autoconf zlib1g-dev \
+ libpcre3-dev libgd-dev libssl-dev libxslt1-dev libxml2-dev libgeoip-dev \
+ libgoogle-perftools-dev libperl-dev libpam0g-dev
 
 rm -rf /usr/local/src/*
 cd /usr/local/src
@@ -16,6 +18,7 @@ git clone https://github.com/openresty/srcache-nginx-module.git
 git clone https://github.com/openresty/set-misc-nginx-module.git
 git clone https://github.com/FRiCKLE/ngx_coolkit.git
 git clone https://github.com/FRiCKLE/ngx_slowfs_cache.git
+git clone https://github.com/sto/ngx_http_auth_pam_module.git
 
 wget https://people.freebsd.org/~osa/ngx_http_redis-0.3.8.tar.gz
 tar -zxf ngx_http_redis-0.3.8.tar.gz
@@ -85,6 +88,7 @@ patch -p1 < nginx__dynamic_tls_records_1.11.5*.patch
  --add-module=/usr/local/src/ngx_http_redis   \
  --add-module=/usr/local/src/ngx_brotli  \
  --add-module=/usr/local/src/ngx_pagespeed-latest-stable  \
+ --add-module=/usr/local/src/ngx_http_auth_pam_module \
  --with-openssl=/usr/local/src/openssl \
  --with-openssl-opt=enable-tls1_3 \
  --sbin-path=/usr/sbin/nginx 

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-apt-get install -y build-essential libtool automake autoconf zlib1g-dev libpcre3-dev libgd-dev libssl-dev libxslt1-dev libxml2-dev libgeoip-dev libgoogle-perftools-dev libperl-dev
+apt-get install -y build-essential libtool automake autoconf zlib1g-dev libpcre3-dev \
+ libgd-dev libssl-dev libxslt1-dev libxml2-dev libgeoip-dev libgoogle-perftools-dev \
+ libperl-dev libpam0g-dev
 
 rm -rf /usr/local/src/*
 cd /usr/local/src
@@ -16,6 +18,7 @@ git clone https://github.com/openresty/srcache-nginx-module.git
 git clone https://github.com/openresty/set-misc-nginx-module.git
 git clone https://github.com/FRiCKLE/ngx_coolkit.git
 git clone https://github.com/FRiCKLE/ngx_slowfs_cache.git
+git clone https://github.com/sto/ngx_http_auth_pam_module.git
 
 wget https://people.freebsd.org/~osa/ngx_http_redis-0.3.8.tar.gz
 tar -zxf ngx_http_redis-0.3.8.tar.gz
@@ -80,6 +83,7 @@ patch -p1 < nginx__dynamic_tls_records_1.11.5*.patch
  --add-module=/usr/local/src/set-misc-nginx-module  \
  --add-module=/usr/local/src/ngx_http_redis   \
  --add-module=/usr/local/src/ngx_brotli  \
+ --add-module=/usr/local/src/ngx_http_auth_pam_module \
  --with-openssl=/usr/local/src/openssl \
  --with-openssl-opt=enable-tls1_3 \
  --sbin-path=/usr/sbin/nginx 


### PR DESCRIPTION
Added `libpam0g-dev` to required packages, because it will allow `mod_auth_pam` to correctly compile.

Added repositories https://github.com/sto/ngx_http_auth_pam_module.git to list of source files and to `--add-module` in order to complete auth_pam support.
