### PR TITLE
various fixes and improvements 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add support for Raspbian
 - Improve documentation
 
+## [3.4.0] - 2018-12-26
+
+### Changed
+
+- Fix gcc setup with nginx stable release
+- Fix arguments parsing for non-interactive install
+- By default Nginx-ee compile the latest mainline release without optional modules like pagespeed or naxsi
+- Fix wrong Nginx version displayed in the compilation summary
+
+### Added
+
+- Interactive install can be launched with the argument -i or --interactive
+- Add WordOps detection
+
 ## [3.3.3] - 2018-12-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # Nginx-EE
 
-## Compile and install the latest nginx releases from source with additional modules with EasyEngine, Plesk Onyx or from scratch
-
 ![nginx-ee](https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-ee.png)
+
+[![Build Status](https://travis-ci.com/VirtuBox/nginx-ee.svg?branch=master)](https://travis-ci.com/VirtuBox/nginx-ee) [![](https://img.shields.io/github/license/VirtuBox/nginx-ee.svg)](https://github.com/VirtuBox/nginx-ee/blob/master/LICENSE) [![](https://img.shields.io/github/stars/VirtuBox/nginx-ee.svg)](https://github.com/VirtuBox/nginx-ee)
+
+Automated Nginx compilation with additional modules for EasyEngine v3, Plesk Onyx or from scratch
 
 ---
 
 ## Features
 
-* Compile the latest Nginx Mainline or Stable Release
+* Compile the latest Nginx release : stable or mainline
 * Install Nginx or replace Nginx package previously installed
-* Nginx official modules selection
-* Nginx Third-party Additonal selection
+* Nginx built-in modules selection
+* Nginx Third-party module selection
+* Dynamic modules support
 * Brotli Support
 * TLS v1.3 support (Final)
 * Cloudflare HPACK (for Mainline release only)
@@ -20,21 +23,21 @@
 
 ## Additional Third-party modules
 
-Nginx current mainline release : **v1.15.7**
+Nginx current mainline release : **v1.15.8**
 Nginx current stable release : **v1.14.2**
 
-* ngx_cache_purge
-* headers-more-nginx-module
+* [ngx_cache_purge](https://github.com/FRiCKLE/ngx_cache_purge)
+* [headers-more-nginx-module](https://github.com/openresty/headers-more-nginx-module)
 * [ngx_brotli](https://github.com/eustas/ngx_brotli)
-* srcache-nginx-module
-* ngx_http_substitutions_filter_module
+* [srcache-nginx-module](https://github.com/openresty/srcache-nginx-module)
+* [ngx_http_substitutions_filter_module](https://github.com/yaoweibin/ngx_http_substitutions_filter_module)
 * [nginx_dynamic_tls_records](https://github.com/nginx-modules/ngx_http_tls_dyn_size)
-* Openssl 1.1.2-dev
+* [OpenSSL](https://github.com/openssl/openssl)
 * [ipscrub](http://www.ipscrub.org/)
-* ngx_http_auth_pam_module
+* [ngx_http_auth_pam_module](https://github.com/sto/ngx_http_auth_pam_module)
 * [virtual-host-traffic-status](https://github.com/vozlt/nginx-module-vts)
 
-optional modules :
+Optional modules :
 
 * [ngx_pagespeed](https://github.com/apache/incubator-pagespeed-ngx) (latest-beta or latest-stable)
 * [naxsi WAF](https://github.com/nbs-system/naxsi)
@@ -48,7 +51,9 @@ optional modules :
 
 * Ubuntu 18.04 LTS (Bionic)
 * Ubuntu 16.04 LTS (Xenial)
-* Debian 8 (Deprecated)
+* Debian 9 (Stretch)
+* Debian 8 (Jessie)
+* Raspbian (Stretch)
 
 ### Plesk releases
 
@@ -75,44 +80,55 @@ optional modules :
 
 <!-- /TOC -->
 
-### Interactive install
+### Default non-interactive install
+
+By default, nginx-ee compile Nginx Mainline release without Pagespeed, Naxsi or RTMP
 
 ```bash
-bash <(wget -qO - https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-build.sh)
+bash <(wget -O - https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-build.sh)
 ```
 
-### Non interactive install
+### Interactive install
+
+Interactive installation is also available
 
 ```bash
-bash <(wget -qO - https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-build.sh) [options] ...
+bash <(wget -O - https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-build.sh) --interactive
+```
+
+### Custom installation
+
+Exemple : Nginx stable release with pagespeed and naxsi
+
+```bash
+bash <(wget -O - https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-build.sh) --stable --pagespeed --naxsi
 ```
 
 #### Options available
 
-Nginx release (required) :
+Nginx build options :
 
-* `--mainline` : compile nginx mainline release
-* `--stable` : compile nginx stable release
+* `--stable` : compile Nginx stable release
+* `--full` : Naxsi + PageSpeed + RTMP
+* `--dynamic` : compile Nginx with dynamic modules
 
-Additional modules (optional)
+Optional third-party modules :
 
 * `--pagespeed`: compile nginx with ngx_pagespeed latest-stable
 * `--pagespeed-beta`: compile nginx with ngx_pagespeed latest-beta
 * `--naxsi` : compile nginx with naxsi
 * `--rtmp` : compile nginx with rtmp module
 
-Example :
-
-Compile Nginx mailine release with pagespeed stable
-
-```bash
-bash <(wget -qO - https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-build.sh) --mainline --pagespeed
-```
-
 ### Nginx modules
 
-You can choose Nginx official modules and third-party modules you want to compile with Nginx-ee.
-The list of official modules built by default and optional modules is available on [Nginx Docs](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/#modules-built-by-default)
+You can choose Nginx built-in and third-party modules you want to compile with Nginx-ee.
+To do so, you can override the list of modules compiled by Nginx-ee by exporting the variable **OVERRIDE_NGINX_MODULES** before launching the script.
+
+Some Nginx modules are built by default and do not have to be specified (for example --with-http_gzip_module isn't required). Default modules can be explicitly excluded with the flag `--without-ngx_module_name`
+But many modules are not built by default and must be listed in the modules to compile, for example you can add mp4 streaming module with  `--with-http_mp4_module`.
+You do not need to use `--without` for modules not built by default with Nginx.
+
+The list of Nginx modules compiled by default and optional modules is available on [Nginx Docs](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/#modules-built-by-default)
 
 To override **official modules** compiled with nginx-ee, export the variable **OVERRIDE_NGINX_MODULES** before launching nginx-ee script.
 
@@ -142,7 +158,7 @@ export OVERRIDE_NGINX_MODULES="--without-http_uwsgi_module \
 
 
 # compile nginx-ee with the modules previously selected
-bash <(wget -qO - https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-build.sh)
+bash <(wget -O - https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-build.sh)
 ```
 
 #### Override list of third-party modules built by default with nginx-ee
@@ -200,7 +216,7 @@ Update nginx ssl_ciphers in `/etc/nginx/nginx.conf` for EasyEngine servers or `/
     # SSL Settings
     ##
     ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers 'TLS13+AESGCM+AES128:EECDH+AES128';
+    ssl_ciphers 'TLS13+AESGCM+AES256:TLS13+AESGCM+AES128:TLS13+CHACHA20:EECDH+CHACHA20:EECDH+AESGCM:EECDH+AES';
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:50m;
     ssl_session_timeout 1d;

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,20 @@
 # Nginx-EE
 
-## Compile and install the latest nginx releases from source with additional modules with EasyEngine, Plesk Onyx or from scratch
-
 ![nginx-ee](https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-ee.png)
+
+[![Build Status](https://travis-ci.com/VirtuBox/nginx-ee.svg?branch=master)](https://travis-ci.com/VirtuBox/nginx-ee) [![](https://img.shields.io/github/license/VirtuBox/nginx-ee.svg)](https://github.com/VirtuBox/nginx-ee/blob/master/LICENSE) [![](https://img.shields.io/github/stars/VirtuBox/nginx-ee.svg)](https://github.com/VirtuBox/nginx-ee)
+
+Automated Nginx compilation with additional modules for EasyEngine v3, Plesk Onyx or from scratch
 
 ---
 
 ## Features
 
-* Compile the latest Nginx Mainline or Stable Release
+* Compile the latest Nginx release : stable or mainline
 * Install Nginx or replace Nginx package previously installed
-* Nginx official modules selection
-* Nginx Third-party Additonal selection
+* Nginx built-in modules selection
+* Nginx Third-party module selection
+* Dynamic modules support
 * Brotli Support
 * TLS v1.3 support (Final)
 * Cloudflare HPACK (for Mainline release only)
@@ -20,21 +23,21 @@
 
 ## Additional Third-party modules
 
-Nginx current mainline release : **v1.15.7**
+Nginx current mainline release : **v1.15.8**
 Nginx current stable release : **v1.14.2**
 
-* ngx_cache_purge
-* headers-more-nginx-module
+* [ngx_cache_purge](https://github.com/FRiCKLE/ngx_cache_purge)
+* [headers-more-nginx-module](https://github.com/openresty/headers-more-nginx-module)
 * [ngx_brotli](https://github.com/eustas/ngx_brotli)
-* srcache-nginx-module
-* ngx_http_substitutions_filter_module
+* [srcache-nginx-module](https://github.com/openresty/srcache-nginx-module)
+* [ngx_http_substitutions_filter_module](https://github.com/yaoweibin/ngx_http_substitutions_filter_module)
 * [nginx_dynamic_tls_records](https://github.com/nginx-modules/ngx_http_tls_dyn_size)
-* Openssl 1.1.2-dev
+* [OpenSSL](https://github.com/openssl/openssl)
 * [ipscrub](http://www.ipscrub.org/)
-* ngx_http_auth_pam_module
+* [ngx_http_auth_pam_module](https://github.com/sto/ngx_http_auth_pam_module)
 * [virtual-host-traffic-status](https://github.com/vozlt/nginx-module-vts)
 
-optional modules :
+Optional modules :
 
 * [ngx_pagespeed](https://github.com/apache/incubator-pagespeed-ngx) (latest-beta or latest-stable)
 * [naxsi WAF](https://github.com/nbs-system/naxsi)
@@ -48,7 +51,9 @@ optional modules :
 
 * Ubuntu 18.04 LTS (Bionic)
 * Ubuntu 16.04 LTS (Xenial)
-* Debian 8 (Deprecated)
+* Debian 9 (Stretch)
+* Debian 8 (Jessie)
+* Raspbian (Stretch)
 
 ### Plesk releases
 
@@ -75,44 +80,55 @@ optional modules :
 
 <!-- /TOC -->
 
-### Interactive install
+### Default non-interactive install
+
+By default, nginx-ee compile Nginx Mainline release without Pagespeed, Naxsi or RTMP
 
 ```bash
-bash <(wget -qO - https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-build.sh)
+bash <(wget -O - https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-build.sh)
 ```
 
-### Non interactive install
+### Interactive install
+
+Interactive installation is also available
 
 ```bash
-bash <(wget -qO - https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-build.sh) [options] ...
+bash <(wget -O - https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-build.sh) --interactive
+```
+
+### Custom installation
+
+Exemple : Nginx stable release with pagespeed and naxsi
+
+```bash
+bash <(wget -O - https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-build.sh) --stable --pagespeed --naxsi
 ```
 
 #### Options available
 
-Nginx release (required) :
+Nginx build options :
 
-* `--mainline` : compile nginx mainline release
-* `--stable` : compile nginx stable release
+* `--stable` : compile Nginx stable release
+* `--full` : Naxsi + PageSpeed + RTMP
+* `--dynamic` : compile Nginx with dynamic modules
 
-Additional modules (optional)
+Optional third-party modules :
 
 * `--pagespeed`: compile nginx with ngx_pagespeed latest-stable
 * `--pagespeed-beta`: compile nginx with ngx_pagespeed latest-beta
 * `--naxsi` : compile nginx with naxsi
 * `--rtmp` : compile nginx with rtmp module
 
-Example :
-
-Compile Nginx mailine release with pagespeed stable
-
-```bash
-bash <(wget -qO - https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-build.sh) --mainline --pagespeed
-```
-
 ### Nginx modules
 
-You can choose Nginx official modules and third-party modules you want to compile with Nginx-ee.
-The list of official modules built by default and optional modules is available on [Nginx Docs](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/#modules-built-by-default)
+You can choose Nginx built-in and third-party modules you want to compile with Nginx-ee.
+To do so, you can override the list of modules compiled by Nginx-ee by exporting the variable **OVERRIDE_NGINX_MODULES** before launching the script.
+
+Some Nginx modules are built by default and do not have to be specified (for example --with-http_gzip_module isn't required). Default modules can be explicitly excluded with the flag `--without-ngx_module_name`
+But many modules are not built by default and must be listed in the modules to compile, for example you can add mp4 streaming module with  `--with-http_mp4_module`.
+You do not need to use `--without` for modules not built by default with Nginx.
+
+The list of Nginx modules compiled by default and optional modules is available on [Nginx Docs](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/#modules-built-by-default)
 
 To override **official modules** compiled with nginx-ee, export the variable **OVERRIDE_NGINX_MODULES** before launching nginx-ee script.
 
@@ -142,7 +158,7 @@ export OVERRIDE_NGINX_MODULES="--without-http_uwsgi_module \
 
 
 # compile nginx-ee with the modules previously selected
-bash <(wget -qO - https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-build.sh)
+bash <(wget -O - https://raw.githubusercontent.com/VirtuBox/nginx-ee/master/nginx-build.sh)
 ```
 
 #### Override list of third-party modules built by default with nginx-ee
@@ -200,7 +216,7 @@ Update nginx ssl_ciphers in `/etc/nginx/nginx.conf` for EasyEngine servers or `/
     # SSL Settings
     ##
     ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers 'TLS13+AESGCM+AES128:EECDH+AES128';
+    ssl_ciphers 'TLS13+AESGCM+AES256:TLS13+AESGCM+AES128:TLS13+CHACHA20:EECDH+CHACHA20:EECDH+AESGCM:EECDH+AES';
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:50m;
     ssl_session_timeout 1d;

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -7,7 +7,7 @@
 # Copyright (c) 2018 VirtuBox <contact@virtubox.net>
 # This script is licensed under M.I.T
 # -------------------------------------------------------------------------
-# Version 3.3.3 - 2018-11-27
+# Version 3.4.0 - 2018-12-26
 # -------------------------------------------------------------------------
 
 # Check if user is root
@@ -17,20 +17,26 @@
 }
 
 # check if curl is installed
-
 [ ! -x /usr/bin/curl ] && {
-    apt-get install curl
-} >>/tmp/nginx-ee.log 2>&1
+    apt-get install curl | sudo tee -a /tmp/nginx-ee.log 2>&1
+}
+
+# Checking lsb_release package
+[ ! -x /usr/bin/lsb_release ] && {
+    sudo apt-get -y install lsb-release | sudo tee -a /tmp/nginx-ee.log 2>&1
+}
 
 ##################################
 # Variables
 ##################################
 
-NAXSI_VER=0.56
-DIR_SRC=/usr/local/src
-NGINX_EE_VER=3.3.3
-NGINX_MAINLINE=$(curl -sL https://nginx.org/en/download.html 2>&1 | grep -E -o 'nginx\-[0-9.]+\.tar[.a-z]*' | awk -F "nginx-" '/.tar.gz$/ {print $2}' | sed -e 's|.tar.gz||g' | head -n 1 2>&1)
-NGINX_STABLE=$(curl -sL https://nginx.org/en/download.html 2>&1 | grep -E -o 'nginx\-[0-9.]+\.tar[.a-z]*' | awk -F "nginx-" '/.tar.gz$/ {print $2}' | sed -e 's|.tar.gz||g' | head -n 2 | grep 1.14 2>&1)
+NAXSI_VER="0.56"
+DIR_SRC="/usr/local/src"
+NGINX_EE_VER="3.4.0"
+NGINX_MAINLINE="$(curl -sL https://nginx.org/en/download.html 2>&1 | grep -E -o 'nginx\-[0-9.]+\.tar[.a-z]*' | awk -F "nginx-" '/.tar.gz$/ {print $2}' | sed -e 's|.tar.gz||g' | head -n 1 2>&1)"
+NGINX_STABLE="$(curl -sL https://nginx.org/en/download.html 2>&1 | grep -E -o 'nginx\-[0-9.]+\.tar[.a-z]*' | awk -F "nginx-" '/.tar.gz$/ {print $2}' | sed -e 's|.tar.gz||g' | head -n 2 | grep 1.14 2>&1)"
+DISTRO_VERSION="$(lsb_release -sc)"
+TLS13_CIPHERS="TLS13+AESGCM+AES256:TLS13+AESGCM+AES128:TLS13+CHACHA20:EECDH+CHACHA20:EECDH+AESGCM:EECDH+AES"
 
 # Colors
 CSI='\033['
@@ -48,13 +54,16 @@ echo "" >/tmp/nginx-ee.log
 
 # detect Plesk
 [ -d /etc/psa ] && {
-    NGINX_PLESK=1
+    NGINX_PLESK="1"
 }
 
 # detect easyengine
 [ -d /etc/ee ] && {
-    NGINX_EASYENGINE=1
-    EE_VALID="YES"
+    NGINX_EASYENGINE="1"
+}
+
+[ -d /etc/wo ] && {
+    NGINX_WO="1"
 }
 
 [ ! -x /usr/sbin/nginx ] && {
@@ -66,28 +75,39 @@ echo "" >/tmp/nginx-ee.log
 # Parse script arguments
 ##################################
 
-while [ ${#} -gt 0 ]; do
+while [ "${#}" -gt 0 ]; do
     case "${1}" in
-        '--pagespeed')
-            PAGESPEED="y"
+    --pagespeed)
+        PAGESPEED="y"
         ;;
-        '--pagespeed-beta')
-            PAGESPEED="y"
-            PAGESPEED_RELEASE="1"
+    --pagespeed-beta)
+        PAGESPEED="y"
+        PAGESPEED_RELEASE="1"
         ;;
-        '--naxsi')
-            NAXSI="y"
+    --full)
+        PAGESPEED="y"
+        NAXSI="y"
+        RTMP="y"
         ;;
-        '--rtmp')
-            RTMP="y"
+    --naxsi)
+        NAXSI="y"
         ;;
-        '--latest' | '--mainline')
-            NGINX_RELEASE=1
+    --rtmp)
+        RTMP="y"
         ;;
-        '--stable')
-            NGINX_RELEASE=2
+    --latest | --mainline)
+        NGINX_RELEASE="1"
         ;;
-        *) ;;
+    --stable)
+        NGINX_RELEASE="2"
+        ;;
+    -i | --interactive)
+        INTERACTIVE_SETUP="1"
+        ;;
+    --dynamic)
+        DYNAMIC_MODULES="1"
+        ;;
+    *) ;;
     esac
     shift
 done
@@ -101,37 +121,42 @@ echo "Welcome to the nginx-ee bash script v${NGINX_EE_VER}"
 echo ""
 
 # interactive
-if [ -z "$NGINX_RELEASE" ]; then
+if [ "$INTERACTIVE_SETUP" = "1" ]; then
     clear
     echo ""
     echo "Do you want to compile the latest Nginx [1] Mainline v${NGINX_MAINLINE} or [2] Stable v${NGINX_STABLE} Release ?"
-    while [[ $NGINX_RELEASE != "1" && $NGINX_RELEASE != "2" ]]; do
+    while [[ "$NGINX_RELEASE" != "1" && "$NGINX_RELEASE" != "2" ]]; do
         read -p "Select an option [1-2]: " NGINX_RELEASE
     done
 
     echo -e '\nDo you want Ngx_Pagespeed ? (y/n)'
-    while [[ $PAGESPEED != "y" && $PAGESPEED != "n" ]]; do
+    while [[ "$PAGESPEED" != "y" && "$PAGESPEED" != "n" ]]; do
         read -p "Select an option [y/n]: " PAGESPEED
     done
     if [ "$PAGESPEED" = "y" ]; then
         echo -e '\nDo you prefer the latest Pagespeed [1] Beta or [2] Stable Release ?'
-        while [[ $PAGESPEED_RELEASE != "1" && $PAGESPEED_RELEASE != "2" ]]; do
+        while [[ "$PAGESPEED_RELEASE" != "1" && "$PAGESPEED_RELEASE" != "2" ]]; do
             read -p "Select an option [1-2]: " PAGESPEED_RELEASE
         done
     fi
     echo -e '\nDo you want NAXSI WAF (still experimental)? (y/n)'
-    while [[ $NAXSI != "y" && $NAXSI != "n" ]]; do
+    while [[ "$NAXSI" != "y" && "$NAXSI" != "n" ]]; do
         read -p "Select an option [y/n]: " NAXSI
     done
 
     echo -e '\nDo you want RTMP streaming module (used for video streaming) ? (y/n)'
-    while [[ $RTMP != "y" && $RTMP != "n" ]]; do
+    while [[ "$RTMP" != "y" && "$RTMP" != "n" ]]; do
         read -p "Select an option [y/n]: " RTMP
     done
     echo ""
 fi
+
+if [ -z "$NGINX_RELEASE" ]; then
+    NGINX_RELEASE=1
+fi
+
 ##################################
-# Set nginx release and modules
+# Set nginx release and HPACK
 ##################################
 
 if [ "$NGINX_RELEASE" = "1" ]; then
@@ -142,19 +167,29 @@ else
     NGX_HPACK=""
 fi
 
-if [ "$RTMP" = "y" ]; then
-    NGINX_CC_OPT=( [index]=--with-cc-opt='-m64 -march=native -DTCP_FASTOPEN=23 -g -O3 -fstack-protector-strong -flto -fuse-ld=gold --param=ssp-buffer-size=4 -Wformat -Werror=format-security -Wimplicit-fallthrough=0 -Wno-error=date-time -D_FORTIFY_SOURCE=2' )
+##################################
+# Set GCC arguments
+##################################
+
+if [ -z "$RTMP" ]; then
+    if [ "$DISTRO_VERSION" == "xenial" ] || [ "$DISTRO_VERSION" == "bionic" ]; then
+        NGINX_CC_OPT=( [index]=--with-cc-opt='-m64 -march=native -DTCP_FASTOPEN=23 -g -O3 -fstack-protector-strong -flto -fuse-ld=gold --param=ssp-buffer-size=4 -Wformat -Werror=format-security -Wimplicit-fallthrough=0 -fcode-hoisting -Wp,-D_FORTIFY_SOURCE=2 -gsplit-dwarf' )
+        NGX_RTMP=""
+        RTMP_VALID="NO"
+    else
+        NGINX_CC_OPT=( [index]=--with-cc-opt='-m64' )
+        NGX_RTMP=""
+        RTMP_VALID="NO"
+    fi
+else
+    NGINX_CC_OPT=( [index]='' )
     NGX_RTMP="--add-module=/usr/local/src/nginx-rtmp-module "
     RTMP_VALID="YES"
-else
-    if [ "$distro_version" == "xenial" ] && [ "$distro_version" == "bionic" ]; then
-        NGINX_CC_OPT=( [index]=--with-cc-opt='-m64 -march=native -DTCP_FASTOPEN=23 -g -O3 -fstack-protector-strong -flto -fuse-ld=gold --param=ssp-buffer-size=4 -Wformat -Werror=format-security -Wimplicit-fallthrough=0 -fcode-hoisting -Wp,-D_FORTIFY_SOURCE=2 -gsplit-dwarf' )
-    else
-        NGINX_CC_OPT=( [index]=--with-cc-opt='-m64 -march=native -DTCP_FASTOPEN=23 -g -O3 -fstack-protector-strong -flto -fuse-ld=gold --param=ssp-buffer-size=4 -Wformat -Werror=format-security -Wimplicit-fallthrough=0 -Wno-error=date-time -D_FORTIFY_SOURCE=2' )
-    fi
-    NGX_RTMP=""
-    RTMP_VALID="NO"
 fi
+
+##################################
+# Set Naxsi module
+##################################
 
 if [ "$NAXSI" = "y" ]; then
     NGX_NAXSI="--add-module=/usr/local/src/naxsi/naxsi_src "
@@ -164,16 +199,24 @@ else
     NAXSI_VALID="NO"
 fi
 
+##################################
+# Set Pagespeed module
+##################################
+
 if [ "$PAGESPEED_RELEASE" = "1" ]; then
     NGX_PAGESPEED="--add-module=/usr/local/src/incubator-pagespeed-ngx-latest-beta "
-    PAGESPEED_VALID="Beta"
-    elif [ "$PAGESPEED_RELEASE" = "2" ]; then
+    PAGESPEED_VALID="beta"
+elif [ "$PAGESPEED_RELEASE" = "2" ]; then
     NGX_PAGESPEED="--add-module=/usr/local/src/incubator-pagespeed-ngx-latest-stable "
-    PAGESPEED_VALID="Stable"
+    PAGESPEED_VALID="stable"
 else
     NGX_PAGESPEED=""
     PAGESPEED_VALID="NO"
 fi
+
+##################################
+# Set Plesk configuration
+##################################
 
 if [ "$NGINX_PLESK" = "1" ]; then
     NGX_USER="--user=nginx --group=nginx"
@@ -183,18 +226,37 @@ else
     PLESK_VALID="NO"
 fi
 
+##################################
+# Set EasyEngine status
+##################################
+
 if [ -z "$NGINX_EASYENGINE" ]; then
     EE_VALID="NO"
 else
     EE_VALID="YES"
 fi
 
+##################################
+# Set WordOps status
+##################################
+
+if [ -z "$NGINX_WO" ]; then
+    WO_VALID="NO"
+else
+    WO_VALID="YES"
+fi
+
+##################################
+# Display Compilation Summary
+##################################
+
 echo "   Compilation summary : "
-echo "       - Nginx release : $NGINX_MAINLINE"
+echo "       - Nginx release : $NGINX_VER"
 echo "       - Pagespeed : $PAGESPEED_VALID "
 echo "       - Naxsi : $NAXSI_VALID"
 echo "       - RTMP : $RTMP_VALID"
 echo "       - EasyEngine : $EE_VALID"
+echo "       - WordOps : $WO_VALID"
 echo "       - Plesk : $PLESK_VALID"
 echo ""
 
@@ -205,10 +267,10 @@ echo ""
 echo -ne '       Installing dependencies               [..]\r'
 apt-get update >>/tmp/nginx-ee.log 2>&1
 apt-get install -y git build-essential libtool automake autoconf zlib1g-dev \
-libpcre3 libpcre3-dev libgd-dev libssl-dev libxslt1-dev libxml2-dev libgeoip-dev libjemalloc1 libjemalloc-dev \
-libbz2-1.0 libreadline-dev libbz2-dev libbz2-ocaml libbz2-ocaml-dev software-properties-common sudo tar zlibc zlib1g zlib1g-dbg \
-libcurl4-openssl-dev libgoogle-perftools-dev libperl-dev libpam0g-dev libbsd-dev zip unzip gnupg gnupg2 pigz libluajit-5.1-common \
-libluajit-5.1-dev libmhash-dev libexpat-dev libgmp-dev autotools-dev bc checkinstall ccache curl debhelper dh-systemd libxml2 >>/tmp/nginx-ee.log 2>&1
+    libpcre3 libpcre3-dev libgd-dev libssl-dev libxslt1-dev libxml2-dev libgeoip-dev libjemalloc1 libjemalloc-dev \
+    libbz2-1.0 libreadline-dev libbz2-dev libbz2-ocaml libbz2-ocaml-dev software-properties-common sudo tar zlibc zlib1g zlib1g-dbg \
+    libcurl4-openssl-dev libgoogle-perftools-dev libperl-dev libpam0g-dev libbsd-dev zip unzip gnupg gnupg2 pigz libluajit-5.1-common \
+    libluajit-5.1-dev libmhash-dev libexpat-dev libgmp-dev autotools-dev bc checkinstall ccache curl debhelper dh-systemd libxml2 >>/tmp/nginx-ee.log 2>&1
 
 if [ $? -eq 0 ]; then
     echo -ne "       Installing dependencies                [${CGREEN}OK${CEND}]\\r"
@@ -220,7 +282,7 @@ else
 fi
 
 ##################################
-# Checking install type
+# Setup Nginx from scratch
 ##################################
 
 if [ "$NGINX_FROM_SCRATCH" = "1" ]; then
@@ -259,29 +321,15 @@ fi
 ##################################
 # Install gcc7 or gcc8 from PPA
 ##################################
-# gcc7 for nginx stable on Ubuntu 16.04 LTS
-# gcc8 for nginx mainline on Ubuntu 16.04 LTS & 18.04 LTS
+# gcc7 if Nginx is compiled with RTMP module
+# otherwise gcc8 is used
 
-# Checking lsb_release package
-if [ ! -x /usr/bin/lsb_release ]; then
-    sudo apt-get -y install lsb-release | sudo tee -a /tmp/nginx-ee.log 2>&1
-fi
-
-# install gcc-7
-distro_version=$(lsb_release -sc)
-
-{
-
-    if [ "$distro_version" == "bionic" ] || [ "$distro_version" == "xenial" ]; then
-        if [ ! -f /etc/apt/sources.list.d/jonathonf-ubuntu-gcc-$(lsb_release -sc).list ]; then
-            add-apt-repository -y ppa:jonathonf/gcc
-            apt-get update
-        fi
+if [ "$DISTRO_VERSION" == "bionic" ] || [ "$DISTRO_VERSION" == "xenial" ]; then
+    if [ ! -f /etc/apt/sources.list.d/jonathonf-ubuntu-gcc-"$(lsb_release -sc)".list ]; then
+        add-apt-repository -y ppa:jonathonf/gcc
+        apt-get update
     fi
-} >>/tmp/nginx-ee.log 2>&1
-
-if [ "$NGINX_RELEASE" == "1" ] && [ "$RTMP" != "y" ]; then
-    if [ "$distro_version" == "bionic" ]; then
+    if [ "$RTMP" != "y" ]; then
         if [ ! -x /usr/bin/gcc-8 ]; then
             echo -ne '       Installing gcc-8                       [..]\r'
             {
@@ -298,29 +346,7 @@ if [ "$NGINX_RELEASE" == "1" ] && [ "$RTMP" != "y" ]; then
                 exit 1
             fi
         fi
-
-        elif [ "$distro_version" == "xenial" ]; then
-
-        if [ ! -x /usr/bin/gcc-8 ]; then
-            echo -ne '       Installing gcc-8                       [..]\r'
-            {
-                apt-get install gcc-8 g++-8 -y  >>/tmp/nginx-ee.log 2>&1
-
-                update-alternatives --remove-all gcc
-                update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-8
-            } >>/tmp/nginx-ee.log 2>&1
-            if [ $? -eq 0 ]; then
-                echo -ne "       Installing gcc-8                       [${CGREEN}OK${CEND}]\\r"
-                echo -ne '\n'
-            else
-                echo -e "        Installing gcc-8                      [${CRED}FAIL${CEND}]"
-                echo -e '\n      Please look at /tmp/nginx-ee.log\n'
-                exit 1
-            fi
-        fi
-    fi
-else
-    if [ "$distro_version" == "xenial" ]; then
+    else
         if [ ! -x /usr/bin/gcc-7 ]; then
             echo -ne '       Installing gcc-7                       [..]\r'
 
@@ -350,12 +376,12 @@ fi
 if [ "$RTMP" = "y" ]; then
     echo -ne '       Installing FFMPEG for RTMP module      [..]\r'
     {
-        if [ "$distro_version" == "xenial" ] && [ ! -f /etc/apt/sources.list.d/jonathonf-ubuntu-ffmpeg-4-xenial.list ]; then
-                sudo add-apt-repository -y ppa:jonathonf/ffmpeg-4
-                sudo apt-get update
-                sudo apt-get install ffmpeg -y
+        if [ "$DISTRO_VERSION" == "xenial" ] && [ ! -f /etc/apt/sources.list.d/jonathonf-ubuntu-ffmpeg-4-xenial.list ]; then
+            add-apt-repository -y ppa:jonathonf/ffmpeg-4
+            apt-get update
+            apt-get install ffmpeg -y
         else
-            sudo apt-get install ffmpeg -y
+            apt-get install ffmpeg -y
         fi
     } >>/tmp/nginx-ee.log 2>&1
     if [ $? -eq 0 ]; then
@@ -375,77 +401,75 @@ fi
 # clear previous compilation archives
 
 cd ${DIR_SRC} || exit
-rm -rf ${DIR_SRC}/{*.tar.gz,nginx,nginx-1.*,openssl,openssl-*,ngx_brotli,pcre,zlib,incubator-pagespeed-*,build_ngx_pagespeed.sh,install,ngx_http_redis*,ngx_cache_purge}
+rm -rf ${DIR_SRC}/{*.tar.gz,nginx,nginx-1.*,openssl,openssl-*,pcre,zlib,incubator-pagespeed-*,build_ngx_pagespeed.sh,install}
 
 echo -ne '       Downloading additionals modules        [..]\r'
 
 {
     # cache_purge module
     { [ -d ${DIR_SRC}/ngx_cache_purge ] && {
-            git -C ${DIR_SRC}/ngx_cache_purge pull origin master
-        }; } || {
+        git -C ${DIR_SRC}/ngx_cache_purge pull origin master
+    }; } || {
         git clone https://github.com/FRiCKLE/ngx_cache_purge.git
     }
-
     # memcached module
     { [ -d ${DIR_SRC}/memc-nginx-module ] && {
-            git -C ${DIR_SRC}/memc-nginx-module pull origin master
-        }; } || {
+        git -C ${DIR_SRC}/memc-nginx-module pull origin master
+    }; } || {
         git clone https://github.com/openresty/memc-nginx-module.git
     }
-
     # devel kit
     { [ -d ${DIR_SRC}/ngx_devel_kit ] && {
-            git -C ${DIR_SRC}/ngx_devel_kit pull origin master
-        }; } || {
+        git -C ${DIR_SRC}/ngx_devel_kit pull origin master
+    }; } || {
         git clone https://github.com/simpl/ngx_devel_kit.git
     }
     # headers-more module
     { [ -d ${DIR_SRC}/headers-more-nginx-module ] && {
-            git -C ${DIR_SRC}/headers-more-nginx-module pull origin master
-        }; } || {
+        git -C ${DIR_SRC}/headers-more-nginx-module pull origin master
+    }; } || {
         git clone https://github.com/openresty/headers-more-nginx-module.git
     }
     # echo module
     { [ -d ${DIR_SRC}/echo-nginx-module ] && {
-            git -C ${DIR_SRC}/echo-nginx-module pull origin master
-        }; } || {
+        git -C ${DIR_SRC}/echo-nginx-module pull origin master
+    }; } || {
         git clone https://github.com/openresty/echo-nginx-module.git
     }
     # http_substitutions_filter module
     { [ -d ${DIR_SRC}/ngx_http_substitutions_filter_module ] && {
-            git -C ${DIR_SRC}/ngx_http_substitutions_filter_module pull origin master
-        }; } || {
+        git -C ${DIR_SRC}/ngx_http_substitutions_filter_module pull origin master
+    }; } || {
         git clone https://github.com/yaoweibin/ngx_http_substitutions_filter_module.git
     }
     # redis2 module
     { [ -d ${DIR_SRC}/redis2-nginx-module ] && {
-            git -C ${DIR_SRC}/redis2-nginx-module pull origin master
-        }; } || {
+        git -C ${DIR_SRC}/redis2-nginx-module pull origin master
+    }; } || {
         git clone https://github.com/openresty/redis2-nginx-module.git
     }
     # srcache module
     { [ -d ${DIR_SRC}/srcache-nginx-module ] && {
-            git -C ${DIR_SRC}/srcache-nginx-module pull origin master
-        }; } || {
+        git -C ${DIR_SRC}/srcache-nginx-module pull origin master
+    }; } || {
         git clone https://github.com/openresty/srcache-nginx-module.git
     }
     # set-misc module
     { [ -d ${DIR_SRC}/set-misc-nginx-module ] && {
-            git -C ${DIR_SRC}/set-misc-nginx-module pull origin master
-        }; } || {
+        git -C ${DIR_SRC}/set-misc-nginx-module pull origin master
+    }; } || {
         git clone https://github.com/openresty/set-misc-nginx-module.git
     }
     # auth_pam module
     { [ -d ${DIR_SRC}/ngx_http_auth_pam_module ] && {
-            git -C ${DIR_SRC}/ngx_http_auth_pam_module pull origin master
-        }; } || {
+        git -C ${DIR_SRC}/ngx_http_auth_pam_module pull origin master
+    }; } || {
         git clone https://github.com/sto/ngx_http_auth_pam_module.git
     }
     # nginx-vts module
     { [ -d ${DIR_SRC}/nginx-module-vts ] && {
-            git -C ${DIR_SRC}/nginx-module-vts pull origin master
-        }; } || {
+        git -C ${DIR_SRC}/nginx-module-vts pull origin master
+    }; } || {
         git clone https://github.com/vozlt/nginx-module-vts.git
     }
     # http redis module
@@ -453,15 +477,15 @@ echo -ne '       Downloading additionals modules        [..]\r'
     mv ngx_http_redis-0.3.8 ngx_http_redis
     if [ "$RTMP" = "y" ]; then
         { [ -d ${DIR_SRC}/nginx-rtmp-module ] && {
-                git -C ${DIR_SRC}/nginx-rtmp-module pull origin master
-            }; } || {
+            git -C ${DIR_SRC}/nginx-rtmp-module pull origin master
+        }; } || {
             git clone https://github.com/arut/nginx-rtmp-module.git
         }
     fi
     # ipscrub module
     { [ -d ${DIR_SRC}/ipscrubtmp ] && {
-            git -C ${DIR_SRC}/ipscrubtmp pull origin master
-        }; } || {
+        git -C ${DIR_SRC}/ipscrubtmp pull origin master
+    }; } || {
         git clone https://github.com/masonicboom/ipscrub.git ipscrubtmp
     }
 
@@ -499,7 +523,7 @@ else
 fi
 
 ##################################
-# Download zlib
+# Download & compile pcre
 ##################################
 
 cd ${DIR_SRC} || exit 1
@@ -514,14 +538,14 @@ if [ ! -x /usr/bin/pcretest ]; then
 
             cd ${DIR_SRC}/pcre || exit 1
             ./configure --prefix=/usr \
-            --enable-utf8 \
-            --enable-unicode-properties \
-            --enable-pcre16 \
-            --enable-pcre32 \
-            --enable-pcregrep-libz \
-            --enable-pcregrep-libbz2 \
-            --enable-pcretest-libreadline \
-            --enable-jit
+                --enable-utf8 \
+                --enable-unicode-properties \
+                --enable-pcre16 \
+                --enable-pcre32 \
+                --enable-pcregrep-libz \
+                --enable-pcregrep-libbz2 \
+                --enable-pcretest-libreadline \
+                --enable-jit
 
             make -j "$(nproc)"
             make install
@@ -543,12 +567,14 @@ fi
 # Download ngx_broti
 ##################################
 
-cd ${DIR_SRC} || exit 1
-
 echo -ne '       Downloading brotli                     [..]\r'
 {
-    git clone https://github.com/eustas/ngx_brotli
-    cd ngx_brotli || exit 1
+    if [ -d $DIR_SRC/ngx_brotli ]; then
+        git -C $DIR_SRC/ngx_brotli pull origin master
+    else
+        git clone https://github.com/eustas/ngx_brotli $DIR_SRC/ngx_brotli
+    fi
+    cd $DIR_SRC/ngx_brotli || exit 1
     git submodule update --init --recursive
 } >>/tmp/nginx-ee.log 2>&1
 
@@ -562,14 +588,14 @@ else
 fi
 
 ##################################
-# Download OpenSSL
+# Download and patch OpenSSL
 ##################################
 
 echo -ne '       Downloading openssl                    [..]\r'
 
 cd ${DIR_SRC} || exit 1
 {
-    git clone https://github.com/openssl/openssl.git
+    git clone https://github.com/openssl/openssl.git $DIR_SRC/openssl
     cd ${DIR_SRC}/openssl || exit 1
 } >>/tmp/nginx-ee.log 2>&1
 
@@ -695,16 +721,8 @@ fi
 
 echo -ne '       Configuring nginx                      [..]\r'
 
-if [ "$distro_version" = "xenial" ] || [ "$distro_version" = "bionic" ]; then
-    if [ "$RTMP" != "y" ]; then
-        export CC="/usr/bin/gcc-8"
-        export CXX="/usr/bin/gc++-8"
-    else
-        export CC="/usr/bin/gcc-7"
-        export CXX="/usr/bin/gc++-7"
-    fi
-fi
 
+# main configuration
 NGINX_BUILD_OPTIONS="--prefix=/usr/share \
 --conf-path=/etc/nginx/nginx.conf \
 --http-log-path=/var/log/nginx/access.log \
@@ -718,65 +736,91 @@ NGINX_BUILD_OPTIONS="--prefix=/usr/share \
 --http-uwsgi-temp-path=/var/lib/nginx/uwsgi \
 --modules-path=/usr/share/nginx/modules"
 
+# built-in modules
 if [ -z "$OVERRIDE_NGINX_MODULES" ]; then
-    NGINX_INCLUDED_MODULES="--without-http_uwsgi_module \
-    --without-mail_imap_module \
-    --without-mail_pop3_module \
-    --without-mail_smtp_module \
-    --with-http_stub_status_module \
-    --with-http_realip_module \
-    --with-http_auth_request_module \
-    --with-http_addition_module \
-    --with-http_geoip_module \
-    --with-http_gzip_static_module \
-    --with-http_image_filter_module \
-    --with-http_mp4_module \
-    --with-http_sub_module"
+    if [ -z "$DYNAMIC_MODULES" ]; then
 
+        NGINX_INCLUDED_MODULES="--without-http_uwsgi_module \
+        --with-http_stub_status_module \
+        --with-http_realip_module \
+        --with-http_auth_request_module \
+        --with-http_addition_module \
+        --with-http_gzip_static_module \
+        --with-http_gunzip_module \
+        --with-http_mp4_module \
+        --with-http_sub_module"
+    else
+        NGINX_INCLUDED_MODULES="--without-http_uwsgi_module \
+        --with-http_stub_status_module \
+        --with-http_realip_module \
+        --with-http_auth_request_module \
+        --with-http_addition_module \
+        --with-http_gzip_static_module \
+        --with-http_gunzip_module \
+        --with-http_mp4_module \
+        --with-http_sub_module--with-mail=dynamic \
+        --with-stream=dynamic \
+        --with-http_geoip_module=dynamic \
+        --with-http_image_filter_module=dynamic "
+    fi
 else
     NGINX_INCLUDED_MODULES="$OVERRIDE_NGINX_MODULES"
 fi
 
+# third party modules
 if [ -z "$OVERRIDE_NGINX_ADDITIONAL_MODULES" ]; then
-    NGINX_THIRD_MODULES="--add-module=/usr/local/src/ngx_http_substitutions_filter_module \
-    --add-module=/usr/local/src/srcache-nginx-module \
-    --add-module=/usr/local/src/ngx_http_redis \
-    --add-module=/usr/local/src/redis2-nginx-module \
-    --add-module=/usr/local/src/memc-nginx-module \
-    --add-module=/usr/local/src/ngx_devel_kit \
-    --add-module=/usr/local/src/set-misc-nginx-module \
-    --add-module=/usr/local/src/ngx_http_auth_pam_module \
-    --add-module=/usr/local/src/nginx-module-vts \
-    --add-module=/usr/local/src/ipscrubtmp/ipscrub"
+    if [ -z "$DYNAMIC_MODULES" ]; then
+        NGINX_THIRD_MODULES="--add-module=/usr/local/src/ngx_http_substitutions_filter_module \
+        --add-module=/usr/local/src/srcache-nginx-module \
+        --add-module=/usr/local/src/ngx_http_redis \
+        --add-module=/usr/local/src/redis2-nginx-module \
+        --add-module=/usr/local/src/memc-nginx-module \
+        --add-module=/usr/local/src/ngx_devel_kit \
+        --add-module=/usr/local/src/set-misc-nginx-module \
+        --add-module=/usr/local/src/ngx_http_auth_pam_module \
+        --add-module=/usr/local/src/nginx-module-vts \
+        --add-module=/usr/local/src/ipscrubtmp/ipscrub"
+    else
+        NGINX_THIRD_MODULES="--add-module=/usr/local/src/ngx_http_substitutions_filter_module \
+        --add-dynamic-module=/usr/local/src/srcache-nginx-module \
+        --add-dynamic-module=/usr/local/src/ngx_http_redis \
+        --add-dynamic-module=/usr/local/src/redis2-nginx-module \
+        --add-dynamic-module=/usr/local/src/memc-nginx-module \
+        --add-module=/usr/local/src/ngx_devel_kit \
+        --add-module=/usr/local/src/set-misc-nginx-module \
+        --add-dynamic-module=/usr/local/src/ngx_http_auth_pam_module \
+        --add-module=/usr/local/src/nginx-module-vts \
+        --add-dynamic-module=/usr/local/src/ipscrubtmp/ipscrub"
+    fi
 else
     NGINX_THIRD_MODULES="$OVERRIDE_NGINX_ADDITIONAL_MODULES"
 fi
 
 ./configure \
-"${NGINX_CC_OPT[@]}" \
-${NGX_NAXSI} \
---with-ld-opt='-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' \
-${NGINX_BUILD_OPTIONS} \
---build='VirtuBox Nginx-ee' \
-${NGX_USER} \
---with-file-aio \
---with-threads \
---with-http_v2_module \
---with-http_ssl_module \
---with-pcre-jit \
-${NGINX_INCLUDED_MODULES} \
-${NGINX_THIRD_MODULES} \
-${NGX_HPACK} \
-${NGX_PAGESPEED} \
-${NGX_RTMP} \
---add-module=/usr/local/src/echo-nginx-module \
---add-module=/usr/local/src/headers-more-nginx-module \
---add-module=/usr/local/src/ngx_cache_purge \
---add-module=/usr/local/src/ngx_brotli \
---with-zlib=/usr/local/src/zlib \
---with-openssl=/usr/local/src/openssl \
---with-openssl-opt='enable-ec_nistp_64_gcc_128 enable-tls1_3' \
---sbin-path=/usr/sbin/nginx >>/tmp/nginx-ee.log 2>&1
+    ${NGX_NAXSI} \
+    "${NGINX_CC_OPT[@]}" \
+    --with-ld-opt='-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now' \
+    ${NGINX_BUILD_OPTIONS} \
+    --build='VirtuBox Nginx-ee' \
+    ${NGX_USER} \
+    --with-file-aio \
+    --with-threads \
+    --with-http_v2_module \
+    --with-http_ssl_module \
+    --with-pcre-jit \
+    ${NGINX_INCLUDED_MODULES} \
+    ${NGINX_THIRD_MODULES} \
+    ${NGX_HPACK} \
+    ${NGX_PAGESPEED} \
+    ${NGX_RTMP} \
+    --add-module=/usr/local/src/echo-nginx-module \
+    --add-module=/usr/local/src/headers-more-nginx-module \
+    --add-module=/usr/local/src/ngx_cache_purge \
+    --add-module=/usr/local/src/ngx_brotli \
+    --with-zlib=/usr/local/src/zlib \
+    --with-openssl=/usr/local/src/openssl \
+    --with-openssl-opt='enable-tls1_3' \
+    --sbin-path=/usr/sbin/nginx >>/tmp/nginx-ee.log 2>&1
 
 if [ $? -eq 0 ]; then
     echo -ne "       Configuring nginx                      [${CGREEN}OK${CEND}]\\r"
@@ -815,29 +859,35 @@ fi
 [ ! -f /etc/apt/preferences.d/nginx-block ] && {
     if [ "$NGINX_PLESK" = "1" ]; then
         {
+            # update nginx ciphers_suites
+            sed -i "s/ssl_ciphers\ \(\"\|'\)\(.*\)\(\"\|'\)/ssl_ciphers \"$TLS13_CIPHERS\"/" /etc/nginx/conf.d/ssl.conf
             # block sw-nginx package updates from APT repository
             echo -e 'Package: sw-nginx*\nPin: release *\nPin-Priority: -1' >/etc/apt/preferences.d/nginx-block
             apt-mark unhold sw-nginx
         } >>/tmp/nginx-ee.log
-        elif [ "$NGINX_EASYENGINE" = "1" ]; then
-        # replace old TLS v1.3 ciphers suite
+    elif [ "$NGINX_EASYENGINE" = "1" ]; then
         {
-            sed -i 's/TLS13-CHACHA20-POLY1305-SHA256:TLS13-AES-256-GCM-SHA384:TLS13-AES-128-GCM-SHA256/TLS13+AESGCM+AES128/' /etc/nginx/nginx.conf
+            # update nginx ciphers_suites
+            sed -i "s/ssl_ciphers\ \(\"\|'\)\(.*\)\(\"\|'\)/ssl_ciphers \"$TLS13_CIPHERS\"/" /etc/nginx/nginx.conf
+            # block sw-nginx package updates from APT repository
             echo -e 'Package: nginx*\nPin: release *\nPin-Priority: -1' >/etc/apt/preferences.d/nginx-block
             apt-mark unhold nginx-ee nginx-common
         } >>/tmp/nginx-ee.log
     else
         {
             echo -e 'Package: nginx*\nPin: release *\nPin-Priority: -1' >/etc/apt/preferences.d/nginx-block
-            apt-mark unhold nginx nginx-full nginx-common
+
         } >>/tmp/nginx-ee.log
     fi
 }
 
+
 {
+    # enable nginx service
     systemctl unmask nginx.service
     systemctl enable nginx.service
     systemctl start nginx.service
+    # remove default configuration
     rm /etc/nginx/{*.default,*.dpkg-dist}
 } >/dev/null 2>&1
 

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -185,7 +185,7 @@ if [ -z "$RTMP" ]; then
         RTMP_VALID="NO"
     fi
 else
-    NGINX_CC_OPT=( [index]='' )
+    NGINX_CC_OPT=( [index]=--with-cc-opt='-m64' )
     NGX_RTMP="--add-module=/usr/local/src/nginx-rtmp-module "
     RTMP_VALID="YES"
 fi
@@ -329,8 +329,10 @@ fi
 
 if [ "$DISTRO_VERSION" == "bionic" ] || [ "$DISTRO_VERSION" == "xenial" ]; then
     if [ ! -f /etc/apt/sources.list.d/jonathonf-ubuntu-gcc-"$(lsb_release -sc)".list ]; then
+    {
         add-apt-repository -y ppa:jonathonf/gcc
         apt-get update
+    } >>/tmp/nginx-ee.log 2>&1
     fi
     if [ "$RTMP" != "y" ]; then
         if [ ! -x /usr/bin/gcc-8 ]; then
@@ -407,9 +409,6 @@ cd ${DIR_SRC} || exit
 rm -rf ${DIR_SRC}/{*.tar.gz,nginx,nginx-1.*,openssl,openssl-*,pcre,zlib,incubator-pagespeed-*,build_ngx_pagespeed.sh,install}
 
 echo -ne '       Downloading additionals modules        [..]\r'
-
-
-
 
 {
     # cache_purge module


### PR DESCRIPTION

### Changed

- Fix gcc setup with nginx stable release
- Fix arguments parsing for non-interactive install
- By default Nginx-ee compile the latest mainline release without optional modules like pagespeed or naxsi
- Fix wrong Nginx version displayed in the compilation summary

### Added

- Interactive install can be launched with the argument -i or --interactive
- Add WordOps detection