### PR TITLE
Develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ addons:
 
 script:
   - sudo echo "Travis Banch = $TRAVIS_BRANCH"
-  - sudo apt-get install -y --force-yes nginx curl wget ccze
+  - sudo apt-get install -y --force-yes curl wget ccze
   - sudo bash nginx-build.sh --travis && sudo bash nginx-build.sh --travis --stable && sudo bash nginx-build.sh --full --travis || sudo bash -c 'tail -n 100 /tmp/nginx-ee.log | ccze -A'
   - sudo ls -alh /usr/sbin/nginx
   - sudo chown -R travis /usr/local/src

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
 script:
   - sudo echo "Travis Banch = $TRAVIS_BRANCH"
   - sudo apt-get install -y --force-yes nginx curl wget ccze
-  - sudo bash nginx-build.sh --openssl-dev --travis && sudo bash nginx-build.sh --travis && sudo bash nginx-build.sh --full --travis || sudo bash -c 'tail -n 100 /tmp/nginx-ee.log | ccze -A'
+  - sudo bash nginx-build.sh --travis && sudo bash nginx-build.sh --travis --stable && sudo bash nginx-build.sh --full --travis || sudo bash -c 'tail -n 100 /tmp/nginx-ee.log | ccze -A'
   - sudo ls -alh /usr/sbin/nginx
   - sudo chown -R travis /usr/local/src
   - sudo chmod 755 /usr/local/src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased] - XX-XX-XX
 
+## [3.6.4] - 2019-08-29
+
 ### Added
 
 - Debian 10 (buster) support
@@ -16,8 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated cronjob
 - Improve module cloning duration by adding `--depth=50` to `git clone`
 - PCRE, OPENSSL & Brotli are not compiled anymore. But are installed from [APT repository](https://build.opensuse.org/project/show/home:virtubox:nginx-ee) excepted Brotli on Debian 8 (jessie)
+- Decrease build duration by 2
 
-# [3.6.3] - 2019-07-15
+## [3.6.3] - 2019-07-15
 
 ### Added
 
@@ -36,7 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Missing OpenSSL patch
 
-# [3.6.2] - 2019-04-24
+## [3.6.2] - 2019-04-24
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Debian 10 (buster) support
+- Raspbian 10 (buster) support
 
 ### Changes
 
 - Updated cronjob
 - Improve module cloning duration by adding `--depth=50` to `git clone`
+- PCRE, OPENSSL & Brotli are not compiled anymore. But are installed from [APT repository](https://build.opensuse.org/project/show/home:virtubox:nginx-ee) excepted Brotli on Debian 8 (jessie)
 
 # [3.6.3] - 2019-07-15
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Automated Nginx compilation from sources with additional modules support
 * Brotli Support
 * TLS v1.3 support (Final)
 * OpenSSL (1.1.1c or 3.0.0-dev or from system-lib) or LibreSSL
-* Cloudflare HPACK (for Mainline release only)
+* Cloudflare HPACK
 * Cloudflare zlib
 * Automated nginx updates cronjob
 * Compilation with GCC-7/8
@@ -102,6 +102,7 @@ Optional modules :
 
 * Ubuntu 19.04 (Disco)
 * Ubuntu 18.10 (Cosmic)
+* Ubuntu 17.10 ()
 * Ubuntu 16.04 LTS (Xenial)
 * Debian 9 (Stretch)
 * Debian 8 (Jessie)

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ Automated Nginx compilation from sources with additional modules support
 <li>Brotli Support</li>
 <li>TLS v1.3 support (Final)</li>
 <li>OpenSSL (1.1.1c or 3.0.0-dev or from system-lib) or LibreSSL</li>
-<li>Cloudflare HPACK (for Mainline release only)</li>
+<li>Cloudflare HPACK</li>
 <li>Cloudflare zlib</li>
 <li>Automated nginx updates cronjob</li>
 <li>Compilation with GCC-7/8</li>

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -156,7 +156,6 @@ readonly DISTRO_NUMBER="$(lsb_release -sr)"
 DEB_CFLAGS="$(dpkg-buildflags --get CPPFLAGS) -Wno-error=date-time"
 DEB_LFLAGS="$(dpkg-buildflags --get LDFLAGS)"
 OPENSSL_COMMIT="3bbec1afed1c65b6f7f645b27808b070e6e7a509"
-PCRE_VER=$(curl -sL https://ftp.pcre.org/pub/pcre/ | grep -E -o 'pcre\-[0-9.]+\.tar[.a-z]*gz' | awk -F "pcre-" '/.tar.gz$/ {print $2}' | sed -e 's|.tar.gz||g' | tail -n 1 2>&1)
 export DEBIAN_FRONTEND=noninteractive
 
 # Colors
@@ -326,7 +325,7 @@ fi
 # Set Brotli lib
 ##################################
 
-if [ $DISTRO_CODENAME = "jessie" ]; then
+if [ "$DISTRO_CODENAME" = "jessie" ]; then
     LIBBROTLI_DEV=""
 else
     LIBBROTLI_DEV="libbrotli-dev"
@@ -770,7 +769,11 @@ _download_brotli() {
         echo -ne '       Downloading brotli                     [..]\r'
         {
             rm /usr/local/src/ngx_brotli -rf
-            git clone --recursive --depth=50 https://github.com/eustas/ngx_brotli /usr/local/src/ngx_brotli -q
+            if [ "$DISTRO_CODENAME" = "jessie" ]; then
+                git clone --recursive --depth=50 https://github.com/eustas/ngx_brotli /usr/local/src/ngx_brotli -q
+            else
+                git clone --depth=50 https://github.com/eustas/ngx_brotli /usr/local/src/ngx_brotli -q
+            fi
 
         } >> /tmp/nginx-ee.log 2>&1
 

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -770,11 +770,7 @@ _download_brotli() {
         echo -ne '       Downloading brotli                     [..]\r'
         {
             rm /usr/local/src/ngx_brotli -rf
-            if [ "$DISTRO_CODENAME" = "jessie" ]; then
-                git clone --recursive --depth=50 https://github.com/eustas/ngx_brotli /usr/local/src/ngx_brotli -q
-            else
-                git clone --depth=50 https://github.com/eustas/ngx_brotli /usr/local/src/ngx_brotli -q
-            fi
+            git clone --recursive --depth=50 https://github.com/eustas/ngx_brotli /usr/local/src/ngx_brotli -q
 
         } >> /tmp/nginx-ee.log 2>&1
 

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -1332,7 +1332,6 @@ fi
 _cleanup_modules
 _download_modules
 _download_zlib
-_download_pcre
 _download_brotli
 if [ "$NAXSI" = "y" ]; then
     _download_naxsi
@@ -1345,7 +1344,7 @@ else
     elif [ "$OPENSSL_LIB" = "3" ]; then
         sleep 1
     else
-        _download_openssl
+        sleep 1
     fi
 fi
 if [ "$PAGESPEED" = "y" ]; then

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -327,9 +327,9 @@ fi
 ##################################
 
 if [ $DISTRO_CODENAME = "jessie" ]; then
-    LIBBROTLI_DEV = ""
+    LIBBROTLI_DEV=""
 else
-    LIBBROTLI_DEV = "libbrotli-dev"
+    LIBBROTLI_DEV="libbrotli-dev"
 fi
 
 ##################################


### PR DESCRIPTION
### Added

- Debian 10 (buster) support
- Raspbian 10 (buster) support

### Changes

- Updated cronjob
- Improve module cloning duration by adding `--depth=50` to `git clone`
- PCRE, OPENSSL & Brotli are not compiled anymore. But are installed from [APT repository](https://build.opensuse.org/project/show/home:virtubox:nginx-ee) excepted Brotli on Debian 8 (jessie)
- Decrease build duration by 2