### PR TITLE
Nginx build tweaks

### DIFF
--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -1154,7 +1154,7 @@ _final_tasks() {
     echo -ne '       Performing final steps                 [..]\r'
     if {
         # block Nginx package update from APT repository
-        if [ "$NGINX_PLESK" = "1" ]; then
+        if [ "$PLESK_VALID" = "YES" ]; then
             {
                 # update nginx ciphers_suites
                 sed -i "s/ssl_ciphers\ \(\"\|.\|'\)\(.*\)\(\"\|.\|'\);/ssl_ciphers \"$TLS13_CIPHERS\";/" /etc/nginx/conf.d/ssl.conf
@@ -1164,7 +1164,7 @@ _final_tasks() {
                 echo -e 'Package: sw-nginx*\nPin: release *\nPin-Priority: -1' >/etc/apt/preferences.d/nginx-block
                 apt-mark hold sw-nginx
             } >>/tmp/nginx-ee.log
-        elif [ "$NGINX_EASYENGINE" = "1" ]; then
+        elif [ "$EE_VALID" = "YES" ]; then
             {
                 # update nginx ssl_protocols
                 sed -i "s/ssl_protocols\ \(.*\);/ssl_protocols TLSv1.2 TLSv1.3;/" /etc/nginx/nginx.conf
@@ -1174,7 +1174,7 @@ _final_tasks() {
                 echo -e 'Package: nginx*\nPin: release *\nPin-Priority: -1' >/etc/apt/preferences.d/nginx-block
                 apt-mark hold nginx-ee nginx-common nginx-custom
             } >>/tmp/nginx-ee.log
-        elif [ "$WO_VALID" = "1" ]; then
+        elif [ "$WO_VALID" = "YES" ]; then
             {
                 # update nginx ssl_protocols
                 sed -i "s/ssl_protocols\ \(.*\);/ssl_protocols TLSv1.2 TLSv1.3;/" /etc/nginx/nginx.conf
@@ -1183,7 +1183,7 @@ _final_tasks() {
                 # block nginx package updates from APT repository
                 echo -e 'Package: nginx*\nPin: release *\nPin-Priority: -1' >/etc/apt/preferences.d/nginx-block
                 CHECK_NGINX_WO=$(dpkg --list | grep nginx-wo)
-                if [ -z "$CHECK_NGINX_WO" ]; then
+                if [ ! -z "$CHECK_NGINX_WO" ]; then
                     apt-mark hold nginx-wo nginx-common nginx-custom
                 else
                     apt-mark hold nginx-ee nginx-common nginx-custom

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -882,9 +882,9 @@ _download_pagespeed() {
             wget -O build_ngx_pagespeed.sh https://raw.githubusercontent.com/pagespeed/ngx_pagespeed/master/scripts/build_ngx_pagespeed.sh
             chmod +x build_ngx_pagespeed.sh
             if [ "$PAGESPEED_RELEASE" = "1" ]; then
-                ./build_ngx_pagespeed.sh --ngx-pagespeed-version latest-beta -b "$DIR_SRC"
+                ./build_ngx_pagespeed.sh --ngx-pagespeed-version latest-beta -b "$DIR_SRC" -y
             else
-                ./build_ngx_pagespeed.sh --ngx-pagespeed-version latest-stable -b "$DIR_SRC"
+                ./build_ngx_pagespeed.sh --ngx-pagespeed-version latest-stable -b "$DIR_SRC" -y
             fi
         } >>/tmp/nginx-ee.log 2>&1
 


### PR DESCRIPTION
# Nginx build tweaks 

## Changes 
- Non interactive pagespeed build (assume yes, `-y` flag)
- Fix final tasks not executed correctly

I experienced stuck while building pagespeed, after checking log file, I noticed that build_ngx_pagespeed.sh send a prompt asking to upgrade/install some deps but not show up on terminal, because the output is sent to log file.
So by adding `-y` flag will execute build_ngx_pagespeed.sh in non interactive mode.
I also noticed that final tasks not executed as intended.

Sorry for my bad english.