### PR TITLE
Nginx-ee v3.6.6 release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,39 @@
+# Auto detect text files and perform LF normalization
+*          text=auto
+
+# Documents
+*.md       text eol=lf
+*.tex      text diff=tex
+*.adoc     text
+*.textile  text
+*.mustache text eol=lf
+*.csv      text
+*.tab      text
+*.tsv      text
+*.txt      text
+*.sql      text
+
+# Scripts
+*.bash     text eol=lf
+*.fish     text eol=lf
+*.sh       text eol=lf
+
+# Source files
+# ============
+*.pxd    text diff=python
+*.py     text diff=python
+*.py3    text diff=python
+*.pyc    text diff=python
+*.pyd    text diff=python
+*.pyo    text diff=python
+*.pyw    text diff=python
+*.pyx    text diff=python
+*.pyz    text diff=python
+
+
+#
+# Exclude files from exporting
+#
+
+.gitattributes export-ignore
+.gitignore     export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased] - XX-XX-XX
 
+## [3.6.6] - 2020-05-02
+
+### Changed
+
+- Update Nginx stable to 1.18.0
+- Update openssl package to 1.1.1g
+
+### Fixed
+
+- Fix final tasks not executed (PR [#90])
+- Fix non interactive pagespeed build (PR [#90])
+
 ## [3.6.5] - 2019-11-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Automated Nginx compilation from sources with additional modules support
 * Dynamic modules support
 * Brotli Support
 * TLS v1.3 support (Final)
-* OpenSSL (1.1.1d or 3.0.0-dev or from system-lib) or LibreSSL
+* OpenSSL (1.1.1g or 3.0.0-dev or from system-lib) or LibreSSL
 * Cloudflare HPACK
 * Cloudflare zlib
 * Automated nginx updates cronjob
@@ -59,8 +59,8 @@ Automated Nginx compilation from sources with additional modules support
 
 ## Additional Third-party modules
 
-Nginx current mainline release : **v1.17.8**
-Nginx current stable release : **v1.16.1**
+Nginx current mainline release : **v1.17.10**
+Nginx current stable release : **v1.18.0**
 
 * [ngx_cache_purge](https://github.com/FRiCKLE/ngx_cache_purge)
 * [headers-more-nginx-module](https://github.com/openresty/headers-more-nginx-module)
@@ -95,6 +95,7 @@ Optional modules :
 
 #### Recommended
 
+* Ubuntu 20.04 LTS (Focal)
 * Ubuntu 18.04 LTS (Bionic)
 * Debian 10 (Buster)
 
@@ -130,7 +131,7 @@ Optional modules :
 **Default settings** :
 
 * mainline release
-* openssl stable : 1.1.1d
+* openssl stable : 1.1.1g
 * without pagespeed
 * without naxsi
 * without rtmp
@@ -202,6 +203,7 @@ Extras :
 * [x] Add more compilation presets
 * [x] Add support for LibreSSL
 * [ ] Add support for config.inc build configuration
+* [ ] Add HTTP/3 QUIC support
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Automated Nginx compilation from sources with additional modules support
 
 ## Additional Third-party modules
 
-Nginx current mainline release : **v1.17.5**
+Nginx current mainline release : **v1.17.8**
 Nginx current stable release : **v1.16.1**
 
 * [ngx_cache_purge](https://github.com/FRiCKLE/ngx_cache_purge)
@@ -101,9 +101,6 @@ Optional modules :
 #### Also compatible
 
 * Ubuntu 19.10 (Eoan)
-* Ubuntu 19.04 (Disco)
-* Ubuntu 18.10 (Cosmic)
-* Ubuntu 17.10 ()
 * Ubuntu 16.04 LTS (Xenial)
 * Debian 9 (Stretch)
 * Debian 8 (Jessie)
@@ -119,7 +116,7 @@ Optional modules :
 
 #### Plesk
 
-* 17.5.x
+* 17.5.x (Onyx)
 * 17.8.x
 * 17.9.x
 * 18.x (Obsidian)
@@ -139,7 +136,7 @@ Optional modules :
 * without rtmp
 
 ```bash
-bash <(wget -O - vtb.cx/nginx-ee || curl -sL vtb.cx/nginx-ee)
+bash <(wget -qO - vtb.cx/nginx-ee || curl -sL vtb.cx/nginx-ee)
 ```
 
 ### Alternative Install Method
@@ -201,10 +198,10 @@ Extras :
 * [x] Add support for Plesk servers
 * [x] Add Nginx modules choice
 * [x] Add support for Debian 9
-* [ ] Add support for config.inc build configuration
 * [x] Add openssl release choice
 * [x] Add more compilation presets
 * [x] Add support for LibreSSL
+* [ ] Add support for config.inc build configuration
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ Automated Nginx compilation from sources with additional modules support
 <li>Dynamic modules support</li>
 <li>Brotli Support</li>
 <li>TLS v1.3 support (Final)</li>
-<li>OpenSSL (1.1.1d or 3.0.0-dev or from system-lib) or LibreSSL</li>
+<li>OpenSSL (1.1.1g or 3.0.0-dev or from system-lib) or LibreSSL</li>
 <li>Cloudflare HPACK</li>
 <li>Cloudflare zlib</li>
 <li>Automated nginx updates cronjob</li>
@@ -53,8 +53,8 @@ Automated Nginx compilation from sources with additional modules support
 </ul>
 <hr />
 <h2 id="additional-third-party-modules">Additional Third-party modules</h2>
-<p>Nginx current mainline release : <strong>v1.17.5</strong>
-Nginx current stable release : <strong>v1.16.1</strong></p>
+<p>Nginx current mainline release : <strong>v1.17.10</strong>
+Nginx current stable release : <strong>v1.18.0</strong></p>
 <ul>
 <li><a href="https://github.com/FRiCKLE/ngx_cache_purge">ngx_cache_purge</a></li>
 <li><a href="https://github.com/openresty/headers-more-nginx-module">headers-more-nginx-module</a></li>
@@ -86,6 +86,7 @@ Nginx current stable release : <strong>v1.16.1</strong></p>
 <h3 id="operating-system">Operating System</h3>
 <h4 id="recommended">Recommended</h4>
 <ul>
+<li>Ubuntu 20.04 LTS (Focal)</li>
 <li>Ubuntu 18.04 LTS (Bionic)</li>
 <li>Debian 10 (Buster)</li>
 </ul>
@@ -119,7 +120,7 @@ Nginx current stable release : <strong>v1.16.1</strong></p>
 <p><strong>Default settings</strong> :</p>
 <ul>
 <li>mainline release</li>
-<li>openssl stable : 1.1.1d</li>
+<li>openssl stable : 1.1.1g</li>
 <li>without pagespeed</li>
 <li>without naxsi</li>
 <li>without rtmp</li>

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -785,7 +785,7 @@ _download_openssl_dev() {
                 git clone --depth=50 https://github.com/openssl/openssl.git /usr/local/src/openssl
                 cd /usr/local/src/openssl || exit 1
                 echo "### git checkout commit ###"
-                git checkout $OPENSSL_COMMIT
+                #git checkout $OPENSSL_COMMIT
             fi
         } >>/tmp/nginx-ee.log 2>&1
 

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -4,10 +4,10 @@
 # -------------------------------------------------------------------------
 # Website:       https://virtubox.net
 # GitHub:        https://github.com/VirtuBox/nginx-ee
-# Copyright (c) 2019 VirtuBox <contact@virtubox.net>
+# Copyright (c) 2019-2020 VirtuBox <contact@virtubox.net>
 # This script is licensed under M.I.T
 # -------------------------------------------------------------------------
-# Version 3.6.5 - 2019-11-18
+# Version 3.6.6 - 2020-05-02
 # -------------------------------------------------------------------------
 
 ##################################
@@ -167,7 +167,7 @@ OS_DISTRO_FULL="$(lsb_release -ds)"
 readonly DISTRO_ID="$(lsb_release -si)"
 readonly DISTRO_CODENAME="$(lsb_release -sc)"
 readonly DISTRO_NUMBER="$(lsb_release -sr)"
-OPENSSL_COMMIT="6f02932edba62186a6866e8c9f0f0714674f6bab"
+OPENSSL_COMMIT="7fa8bcfe4342df41919f5564b315f9c85d0a02d6"
 
 # Colors
 CSI='\033['

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -771,14 +771,14 @@ _download_openssl_dev() {
                     git clone --depth=50 https://github.com/openssl/openssl.git /usr/local/src/openssl
                     cd /usr/local/src/openssl || exit 1
                     echo "### git checkout commit ###"
-                    git checkout $OPENSSL_COMMIT
+                    #git checkout $OPENSSL_COMMIT
                 else
                     cd /usr/local/src/openssl || exit 1
                     echo "### reset openssl to master and clean patches ###"
                     git fetch --all
                     git reset --hard origin/master
                     git clean -f
-                    git checkout $OPENSSL_COMMIT
+                    #git checkout $OPENSSL_COMMIT
                 fi
             else
                 echo "### cloning openssl ###"
@@ -799,7 +799,7 @@ _download_openssl_dev() {
             cd /usr/local/src/openssl || exit 1
             # apply openssl ciphers patch
             echo "### openssl ciphers patch ###"
-            patch -p1 <../openssl-patch/openssl-equal-3.0.0-dev_ciphers.patch
+            #patch -p1 <../openssl-patch/openssl-equal-3.0.0-dev_ciphers.patch
         } >>/tmp/nginx-ee.log 2>&1
 
     }; then

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -158,9 +158,9 @@ fi
 DIR_SRC="/usr/local/src"
 NGINX_EE_VER=$(curl -m 5 --retry 3 -sL https://api.github.com/repos/VirtuBox/nginx-ee/releases/latest 2>&1 | jq -r '.tag_name')
 NGINX_MAINLINE="$(curl -sL https://nginx.org/en/download.html 2>&1 | grep -E -o 'nginx\-[0-9.]+\.tar[.a-z]*' | awk -F "nginx-" '/.tar.gz$/ {print $2}' | sed -e 's|.tar.gz||g' | head -n 1 2>&1)"
-NGINX_STABLE="$(curl -sL https://nginx.org/en/download.html 2>&1 | grep -E -o 'nginx\-[0-9.]+\.tar[.a-z]*' | awk -F "nginx-" '/.tar.gz$/ {print $2}' | sed -e 's|.tar.gz||g' | head -n 2 | grep 1.16 2>&1)"
+NGINX_STABLE="$(curl -sL https://nginx.org/en/download.html 2>&1 | grep -E -o 'nginx\-[0-9.]+\.tar[.a-z]*' | awk -F "nginx-" '/.tar.gz$/ {print $2}' | sed -e 's|.tar.gz||g' | head -n 2 | grep 1.18 2>&1)"
 LIBRESSL_VER="3.0.2"
-OPENSSL_VER="1.1.1d"
+OPENSSL_VER="1.1.1g"
 TLS13_CIPHERS="TLS13+AESGCM+AES256:TLS13+AESGCM+AES128:TLS13+CHACHA20:EECDH+CHACHA20:EECDH+AESGCM:EECDH+AES"
 readonly OS_ARCH="$(uname -m)"
 OS_DISTRO_FULL="$(lsb_release -ds)"

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -1163,7 +1163,7 @@ _final_tasks() {
                 # block sw-nginx package updates from APT repository
                 echo -e 'Package: sw-nginx*\nPin: release *\nPin-Priority: -1' >/etc/apt/preferences.d/nginx-block
                 apt-mark hold sw-nginx
-            } >>/tmp/nginx-ee.log
+            } >>/tmp/nginx-ee.log 2>&1
         elif [ "$NGINX_EASYENGINE" = "1" ]; then
             {
                 # update nginx ssl_protocols
@@ -1173,7 +1173,7 @@ _final_tasks() {
                 # block nginx package updates from APT repository
                 echo -e 'Package: nginx*\nPin: release *\nPin-Priority: -1' >/etc/apt/preferences.d/nginx-block
                 apt-mark hold nginx-ee nginx-common nginx-custom
-            } >>/tmp/nginx-ee.log
+            } >>/tmp/nginx-ee.log 2>&1
         elif [ "$WO_VALID" = "1" ]; then
             {
                 # update nginx ssl_protocols
@@ -1188,7 +1188,7 @@ _final_tasks() {
                 else
                     apt-mark hold nginx-ee nginx-common nginx-custom
                 fi
-            } >>/tmp/nginx-ee.log
+            } >>/tmp/nginx-ee.log 2>&1
         fi
 
         {


### PR DESCRIPTION
## Changes 
- update Nginx stable to 1.18.0
- update openssl package to 1.1.1g
- Fix final tasks not executed (PR [#90])
- Fix non interactive pagespeed build (PR [#90])