### PR TITLE
Add HTTP/3 QUIC Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased] - XX-XX-XX
 
+## [3.8.0] - 2024-04-23
+
+### Added
+
+- `--with-http_v3_module` on Mainline release
+- Full HTTP/3 QUIC support on Mainline release with LibreSSL
+
+### Changed
+
+- LibreSSL release bumped to 3.8.4
+
 ## [3.7.1] - 2023-05-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - LibreSSL release bumped to 3.8.4
+- Update zlib to 1.2.13 by @WinSCaP in [#146](https://github.com/VirtuBox/nginx-ee/pull/146)
+
+### Fixed
+
+- Fix compile error due to Brotli by @janiosarmento in [#151](https://github.com/VirtuBox/nginx-ee/pull/152)
 
 ## [3.7.1] - 2023-05-08
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,12 @@ Automated Nginx compilation from sources with additional modules support
 * Nginx built-in modules selection
 * Nginx Third-party modules selection
 * Dynamic modules support
+* HTTP/3 QUIC Support with Mainline Release
 * Brotli Support
-* TLS v1.3 support (Final)
+* TLS v1.3 support
 * OpenSSL or LibreSSL
-* Cloudflare HPACK
 * Cloudflare zlib
 * Automated nginx updates cronjob
-* Compilation with GCC-7/9
 * Security hardening and performance optimization enabled with proper GCC flags
 * An option to omit nginx configuration, allowing usage of third party devops tools
 
@@ -59,8 +58,8 @@ Automated Nginx compilation from sources with additional modules support
 
 ## Additional Third-party modules
 
-Nginx current mainline release : **v1.23.4**
-Nginx current stable release : **v1.24.0**
+Nginx current mainline release : **v1.25.5** with HTTP/3 QUIC
+Nginx current stable release : **v1.24.0** with Cloudflare HTTP/2 HPACK
 
 * [ngx_cache_purge](https://github.com/FRiCKLE/ngx_cache_purge)
 * [headers-more-nginx-module](https://github.com/openresty/headers-more-nginx-module)
@@ -84,7 +83,7 @@ For Nginx http_ssl_module :
 
 Optional modules :
 
-* [naxsi WAF](https://github.com/nbs-system/naxsi)
+* [naxsi WAF](https://github.com/wargio/naxsi)
 * [nginx-rtmp-module](https://github.com/arut/nginx-rtmp-module)
 
 ---
@@ -120,6 +119,10 @@ Optional modules :
 * 17.9.x
 * 18.x (Obsidian)
 
+### HTTP/3 QUIC
+
+Full support of HTTP/3 QUIC is only available with Nginx mainline release and compiled with LibreSSL. More information [here](https://nginx.org/en/docs/http/ngx_http_v3_module.html).
+
 ---
 
 ## Usage
@@ -128,7 +131,7 @@ Optional modules :
 
 **Default settings** :
 
-* mainline release
+* mainline release with HTTP/3
 * openssl from system
 * without naxsi
 * without rtmp
@@ -155,7 +158,7 @@ bash <(wget -O - vtb.cx/nginx-ee || curl -sL vtb.cx/nginx-ee) --interactive
 
 ### Custom installation
 
-Example : Nginx stable release with naxsi
+Example : Nginx stable release HTTP/2 with naxsi
 
 ```bash
 bash <(wget -O - vtb.cx/nginx-ee || curl -sL vtb.cx/nginx-ee) --stable --naxsi
@@ -165,7 +168,7 @@ bash <(wget -O - vtb.cx/nginx-ee || curl -sL vtb.cx/nginx-ee) --stable --naxsi
 
 Nginx build options :
 
-* `--stable` : compile Nginx stable release
+* `--stable` : compile Nginx stable release with HTTP/2
 * `--full` : Naxsi + RTMP
 * `--dynamic` : Compile Nginx modules as dynamic modules
 * `--noconf` : Compile Nginx without any configuring. Useful when you use devops tools like ansible.
@@ -198,7 +201,7 @@ Extras :
 * [x] Add support for LibreSSL
 * [x] Add noconf support
 * [ ] Add support for config.inc build configuration
-* [ ] Add HTTP/3 QUIC support
+* [x] Add HTTP/3 QUIC support
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Optional modules :
 
 ### HTTP/3 QUIC
 
-Full support of HTTP/3 QUIC is only available with Nginx mainline release and compiled with LibreSSL. More information [here](https://nginx.org/en/docs/http/ngx_http_v3_module.html).
+**Full support of HTTP/3 QUIC is only available with Nginx mainline release and compiled with LibreSSL**. More information [here](https://nginx.org/en/docs/http/ngx_http_v3_module.html).
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,19 +42,18 @@ Automated Nginx compilation from sources with additional modules support
 <li>Nginx built-in modules selection</li>
 <li>Nginx Third-party modules selection</li>
 <li>Dynamic modules support</li>
+<li>HTTP/3 QUIC Support with Mainline Release</li>
 <li>Brotli Support</li>
 <li>TLS v1.3 support (Final)</li>
 <li>OpenSSL or LibreSSL</li>
-<li>Cloudflare HPACK</li>
 <li>Cloudflare zlib</li>
 <li>Automated nginx updates cronjob</li>
-<li>Compilation with GCC-7/9</li>
 <li>Security hardening and performance optimization enabled with proper GCC flags</li>
 </ul>
 <hr />
 <h2 id="additional-third-party-modules">Additional Third-party modules</h2>
-<p>Nginx current mainline release : <strong>v1.23.4</strong>
-Nginx current stable release : <strong>v1.24.0</strong></p>
+<p>Nginx current mainline release : <strong>v1.25.5</strong> with HTTP/3 QUIC
+Nginx current stable release : <strong>v1.24.0</strong></p> with Cloudflare HTTP/2 HPACK
 <ul>
 <li><a href="https://github.com/FRiCKLE/ngx_cache_purge">ngx_cache_purge</a></li>
 <li><a href="https://github.com/openresty/headers-more-nginx-module">headers-more-nginx-module</a></li>
@@ -77,7 +76,7 @@ Nginx current stable release : <strong>v1.24.0</strong></p>
 </ul>
 <p>Optional modules :</p>
 <ul>
-<li><a href="https://github.com/nbs-system/naxsi">naxsi WAF</a></li>
+<li><a href="https://github.com/wargio/naxsi">naxsi WAF</a></li>
 <li><a href="https://github.com/arut/nginx-rtmp-module">nginx-rtmp-module</a></li>
 </ul>
 <hr />
@@ -109,12 +108,15 @@ Nginx current stable release : <strong>v1.24.0</strong></p>
 <li>17.9.x</li>
 <li>18.x (Obsidian)</li>
 </ul>
+<h3>### HTTP/3 QUIC</h3>
+<p><strong>Full support of HTTP/3 QUIC is only available with Nginx mainline release and compiled with LibreSSL**</strong>. More information [here](https://nginx.org/en/docs/http/ngx_http_v3_module.html).</p>
+
 <hr />
 <h2 id="usage">Usage</h2>
 <h3 id="one-step-automated-install">One-Step Automated Install</h3>
 <p><strong>Default settings</strong> :</p>
 <ul>
-<li>mainline release</li>
+<li>mainline release with HTTP/3</li>
 <li>openssl from system lib</li>
 <li>without naxsi</li>
 <li>without rtmp</li>
@@ -131,7 +133,7 @@ sudo bash nginx-build.sh
 <pre><code class="language-bash">bash &lt;(wget -O - vtb.cx/nginx-ee || curl -sL vtb.cx/nginx-ee) --interactive
 </code></pre>
 <h3 id="custom-installation">Custom installation</h3>
-<p>Example : Nginx stable release with naxsi</p>
+<p>Example : Nginx stable release with HTTP/2 HPACK with naxsi</p>
 <pre><code class="language-bash">bash &lt;(wget -O - vtb.cx/nginx-ee || curl -sL vtb.cx/nginx-ee) --stable --naxsi
 </code></pre>
 <h4 id="options-available">Options available</h4>
@@ -177,6 +179,7 @@ Feel free to use the custom Nginx package built for WordOps and available on <a 
 <li class="task-list-item"><input disabled="disabled" type="checkbox" checked="checked" /> Add openssl release choice</li>
 <li class="task-list-item"><input disabled="disabled" type="checkbox" checked="checked" /> Add more compilation presets</li>
 <li class="task-list-item"><input disabled="disabled" type="checkbox" checked="checked" /> Add support for LibreSSL</li>
+<li class="task-list-item"><input disabled="disabled" type="checkbox" checked="checked" /> Add support for HTTP/3 QUIC</li>
 </ul>
 <hr />
 

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -4,10 +4,10 @@
 # -------------------------------------------------------------------------
 # Website:       https://virtubox.net
 # GitHub:        https://github.com/VirtuBox/nginx-ee
-# Copyright (c) 2019-2020 VirtuBox <contact@virtubox.net>
+# Copyright (c) 2019-2024 VirtuBox <contact@virtubox.net>
 # This script is licensed under M.I.T
 # -------------------------------------------------------------------------
-# Version 3.8.0 - 2023-05-08
+# Version 3.9.0 - 2024-04-23
 # -------------------------------------------------------------------------
 
 ##################################

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -239,9 +239,11 @@ fi
 if [ "$NGINX_RELEASE" = "2" ]; then
     NGINX_VER="$NGINX_STABLE"
     NGX_HPACK="--with-http_v2_hpack_enc"
+    NGX_QUIC=""
 else
     NGINX_VER="$NGINX_MAINLINE"
     NGX_HPACK=""
+    NGX_QUIC="--with-http_v3_module"
 fi
 
 ##################################
@@ -274,7 +276,6 @@ fi
 
 if [ "$LIBRESSL" = "y" ]; then
     NGX_SSL_LIB="--with-openssl=../libressl"
-    NGX_QUIC="--with-http_v3_module"
     QUIC_VALID="YES"
     LIBRESSL_VALID="YES"
     OPENSSL_OPT=""
@@ -286,7 +287,6 @@ else
             OPENSSL_OPT="enable-tls1_3"
         fi
     fi
-    NGX_QUIC=""
     QUIC_VALID="NO"
     NGX_SSL_LIB=""
     OPENSSL_VALID="from system"

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -7,7 +7,7 @@
 # Copyright (c) 2019-2024 VirtuBox <contact@virtubox.net>
 # This script is licensed under M.I.T
 # -------------------------------------------------------------------------
-# Version 3.9.0 - 2024-04-23
+# Version 3.8.0 - 2024-04-23
 # -------------------------------------------------------------------------
 
 ##################################
@@ -26,19 +26,17 @@ _help() {
     echo " -------------------------------------------------------------------- "
     echo ""
     echo "Usage: ./nginx-ee <options> [modules]"
-    echo "By default, Nginx-ee will compile the latest Nginx mainline release without Pagespeed, Naxsi or RTMP module"
+    echo "By default, Nginx-ee will compile the latest Nginx mainline release with HTTP/3 and without Naxsi or RTMP module"
     echo "  Options:"
     echo "       -h, --help ..... display this help"
     echo "       -i, --interactive ....... interactive installation"
     echo "       --stable ..... Nginx stable release"
-    echo "       --full ..... Nginx mainline release with Nasxi and RTMP module"
+    echo "       --full ..... Nginx with Nasxi and RTMP module"
     echo "       --dynamic ..... Compile Nginx modules as dynamic"
     echo "       --noconf ..... Compile Nginx without any configuring. Useful when you use devops tools like ansible."
     echo "  Modules:"
     echo "       --naxsi ..... Naxsi WAF module"
     echo "       --rtmp ..... RTMP video streaming module"
-    echo "       --openssl-dev ..... Compile Nginx with OpenSSL 3.0.0-dev"
-    echo "       --openssl-system ..... Compile Nginx with OpenSSL from system lib"
     echo "       --libressl ..... Compile Nginx with LibreSSL"
     echo ""
     return 0
@@ -325,10 +323,20 @@ echo ""
 echo -e "  - Nginx release : $NGINX_VER"
 [ -n "$OPENSSL_VALID" ] && {
     echo -e "  - OPENSSL : $OPENSSL_VER"
+    if [ "$NGINX_RELEASE" = "2" ]; then
+        echo -e "  - HTTP/2 HPACK : YES"
+    else
+        echo -e "  - with HTTP/3 : YES"
+    fi
+
 }
 [ -n "$LIBRESSL_VALID" ] && {
     echo -e "  - LIBRESSL : $LIBRESSL_VALID"
-    echo -e "  - HTTP/3 QUIC : $QUIC_VALID"
+    if [ "$NGINX_RELEASE" = "2" ]; then
+        echo -e "  - HTTP/2 HPACK : YES"
+    else
+        echo -e "  - HTTP/3 QUIC : YES"
+    fi
 }
 echo "  - Dynamic modules $DYNAMIC_MODULES_VALID"
 echo "  - Naxsi : $NAXSI_VALID"

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -274,6 +274,8 @@ fi
 
 if [ "$LIBRESSL" = "y" ]; then
     NGX_SSL_LIB="--with-openssl=../libressl"
+    NGX_QUIC="--with-http_v3_module"
+    QUIC_VALID="YES"
     LIBRESSL_VALID="YES"
     OPENSSL_OPT=""
 else
@@ -284,30 +286,13 @@ else
             OPENSSL_OPT="enable-tls1_3"
         fi
     fi
+    NGX_QUIC=""
+    QUIC_VALID="NO"
     NGX_SSL_LIB=""
     OPENSSL_VALID="from system"
     LIBSSL_DEV="libssl-dev"
 
 fi
-
-##################################
-# Set LibreSSL HTTP/3 QUIC
-##################################
-
-if "$LIBRESSL_VALID"; then
-    NGX_QUIC="--with-http_v3_module"
-    QUIC_VALID="YES"
-else
-    NGX_QUIC=""
-    QUIC_VALID="NO"
-fi
-
-##################################
-# Set Pagespeed module
-##################################
-
-NGX_PAGESPEED=""
-PAGESPEED_VALID="NO"
 
 ##################################
 # Set Plesk configuration


### PR DESCRIPTION
### Added

- `--with-http_v3_module` on Mainline release
- Full HTTP/3 QUIC support on Mainline release with LibreSSL

### Changed

- LibreSSL release bumped to 3.8.4