### PR TITLE
Update Nginx stable and few improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - HTTP/3 now available on both mainline and stable release
 - Always download latest zlib library if zlib-cf not supported
 - Always download the latest libressl release
+- HTTP/2 HPACK removed
 
 ## [3.8.0] - 2024-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased] - XX-XX-XX
 
+## [3.8.1] - 2024-04-24
+
+### Changed
+
+- Nginx stable release bumped to 1.26.0
+- HTTP/3 now available on both mainline and stable release
+- Always download latest zlib library if zlib-cf not supported
+- Always download the latest libressl release
+
 ## [3.8.0] - 2024-04-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased] - XX-XX-XX
 
+## [3.8.0] - 2024-04-23
+
+### Added
+
+- `--with-http_v3_module` on Mainline release
+- Full HTTP/3 QUIC support on Mainline release with LibreSSL
+
+### Changed
+
+- LibreSSL release bumped to 3.8.4
+
 ## [3.7.1] - 2023-05-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - LibreSSL release bumped to 3.8.4
+- Update zlib to 1.2.13 by @WinSCaP in [#146](https://github.com/VirtuBox/nginx-ee/pull/146)
+
+### Fixed
+
+- Fix compile error due to Brotli by @janiosarmento in [#151](https://github.com/VirtuBox/nginx-ee/pull/152)
 
 ## [3.7.1] - 2023-05-08
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,12 @@ Automated Nginx compilation from sources with additional modules support
 * Nginx built-in modules selection
 * Nginx Third-party modules selection
 * Dynamic modules support
+* HTTP/3 QUIC Support with Mainline Release
 * Brotli Support
-* TLS v1.3 support (Final)
+* TLS v1.3 support
 * OpenSSL or LibreSSL
-* Cloudflare HPACK
 * Cloudflare zlib
 * Automated nginx updates cronjob
-* Compilation with GCC-7/9
 * Security hardening and performance optimization enabled with proper GCC flags
 * An option to omit nginx configuration, allowing usage of third party devops tools
 
@@ -59,8 +58,8 @@ Automated Nginx compilation from sources with additional modules support
 
 ## Additional Third-party modules
 
-Nginx current mainline release : **v1.23.4**
-Nginx current stable release : **v1.24.0**
+Nginx current mainline release : **v1.25.5** with HTTP/3 QUIC
+Nginx current stable release : **v1.24.0** with Cloudflare HTTP/2 HPACK
 
 * [ngx_cache_purge](https://github.com/FRiCKLE/ngx_cache_purge)
 * [headers-more-nginx-module](https://github.com/openresty/headers-more-nginx-module)
@@ -84,7 +83,7 @@ For Nginx http_ssl_module :
 
 Optional modules :
 
-* [naxsi WAF](https://github.com/nbs-system/naxsi)
+* [naxsi WAF](https://github.com/wargio/naxsi)
 * [nginx-rtmp-module](https://github.com/arut/nginx-rtmp-module)
 
 ---
@@ -120,6 +119,10 @@ Optional modules :
 * 17.9.x
 * 18.x (Obsidian)
 
+### HTTP/3 QUIC
+
+Full support of HTTP/3 QUIC is only available with Nginx mainline release and compiled with LibreSSL. More information [here](https://nginx.org/en/docs/http/ngx_http_v3_module.html).
+
 ---
 
 ## Usage
@@ -128,7 +131,7 @@ Optional modules :
 
 **Default settings** :
 
-* mainline release
+* mainline release with HTTP/3
 * openssl from system
 * without naxsi
 * without rtmp
@@ -155,7 +158,7 @@ bash <(wget -O - vtb.cx/nginx-ee || curl -sL vtb.cx/nginx-ee) --interactive
 
 ### Custom installation
 
-Example : Nginx stable release with naxsi
+Example : Nginx stable release HTTP/2 with naxsi
 
 ```bash
 bash <(wget -O - vtb.cx/nginx-ee || curl -sL vtb.cx/nginx-ee) --stable --naxsi
@@ -165,7 +168,7 @@ bash <(wget -O - vtb.cx/nginx-ee || curl -sL vtb.cx/nginx-ee) --stable --naxsi
 
 Nginx build options :
 
-* `--stable` : compile Nginx stable release
+* `--stable` : compile Nginx stable release with HTTP/2
 * `--full` : Naxsi + RTMP
 * `--dynamic` : Compile Nginx modules as dynamic modules
 * `--noconf` : Compile Nginx without any configuring. Useful when you use devops tools like ansible.
@@ -198,7 +201,7 @@ Extras :
 * [x] Add support for LibreSSL
 * [x] Add noconf support
 * [ ] Add support for config.inc build configuration
-* [ ] Add HTTP/3 QUIC support
+* [x] Add HTTP/3 QUIC support
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Optional modules :
 
 ### HTTP/3 QUIC
 
-Full support of HTTP/3 QUIC is only available with Nginx mainline release and compiled with LibreSSL. More information [here](https://nginx.org/en/docs/http/ngx_http_v3_module.html).
+**Full support of HTTP/3 QUIC is only available with Nginx mainline release and compiled with LibreSSL**. More information [here](https://nginx.org/en/docs/http/ngx_http_v3_module.html).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </h1>
 
 <h4 align="center">
-Automated Nginx compilation from sources with additional modules support
+Automated Nginx compilation from sources with HTTP/3 QUIC and additional modules support
 </h4>
 
 ---
@@ -45,7 +45,7 @@ Automated Nginx compilation from sources with additional modules support
 * Nginx built-in modules selection
 * Nginx Third-party modules selection
 * Dynamic modules support
-* HTTP/3 QUIC Support with Mainline Release
+* HTTP/3 QUIC Support
 * Brotli Support
 * TLS v1.3 support
 * OpenSSL or LibreSSL
@@ -59,7 +59,7 @@ Automated Nginx compilation from sources with additional modules support
 ## Additional Third-party modules
 
 Nginx current mainline release : **v1.25.5** with HTTP/3 QUIC
-Nginx current stable release : **v1.24.0** with Cloudflare HTTP/2 HPACK
+Nginx current stable release : **v1.26.0** with HTTP/3 QUIC
 
 * [ngx_cache_purge](https://github.com/FRiCKLE/ngx_cache_purge)
 * [headers-more-nginx-module](https://github.com/openresty/headers-more-nginx-module)
@@ -121,7 +121,7 @@ Optional modules :
 
 ### HTTP/3 QUIC
 
-**Full support of HTTP/3 QUIC is only available with Nginx mainline release and compiled with LibreSSL**. More information [here](https://nginx.org/en/docs/http/ngx_http_v3_module.html).
+**Full support of HTTP/3 QUIC is only available with LibreSSL**. More information [here](https://nginx.org/en/docs/http/ngx_http_v3_module.html).
 
 ---
 
@@ -158,7 +158,7 @@ bash <(wget -O - vtb.cx/nginx-ee || curl -sL vtb.cx/nginx-ee) --interactive
 
 ### Custom installation
 
-Example : Nginx stable release HTTP/2 with naxsi
+Example : Nginx stable release HTTP/3 with naxsi
 
 ```bash
 bash <(wget -O - vtb.cx/nginx-ee || curl -sL vtb.cx/nginx-ee) --stable --naxsi
@@ -168,7 +168,7 @@ bash <(wget -O - vtb.cx/nginx-ee || curl -sL vtb.cx/nginx-ee) --stable --naxsi
 
 Nginx build options :
 
-* `--stable` : compile Nginx stable release with HTTP/2
+* `--stable` : compile Nginx stable release with HTTP/3
 * `--full` : Naxsi + RTMP
 * `--dynamic` : Compile Nginx modules as dynamic modules
 * `--noconf` : Compile Nginx without any configuring. Useful when you use devops tools like ansible.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ Automated Nginx compilation from sources with additional modules support
 <li>Nginx built-in modules selection</li>
 <li>Nginx Third-party modules selection</li>
 <li>Dynamic modules support</li>
-<li>HTTP/3 QUIC Support with Mainline Release</li>
+<li>HTTP/3 QUIC Support</li>
 <li>Brotli Support</li>
 <li>TLS v1.3 support (Final)</li>
 <li>OpenSSL or LibreSSL</li>
@@ -52,8 +52,8 @@ Automated Nginx compilation from sources with additional modules support
 </ul>
 <hr />
 <h2 id="additional-third-party-modules">Additional Third-party modules</h2>
-<p>Nginx current mainline release : <strong>v1.25.5</strong> with HTTP/3 QUIC
-Nginx current stable release : <strong>v1.24.0</strong></p> with Cloudflare HTTP/2 HPACK
+<p>Nginx current mainline release : <strong>v1.25.5</strong> with HTTP/3 QUIC</p>
+<p>Nginx current stable release : <strong>v1.26.0</strong> with HTTP/3 QUIC</p>
 <ul>
 <li><a href="https://github.com/FRiCKLE/ngx_cache_purge">ngx_cache_purge</a></li>
 <li><a href="https://github.com/openresty/headers-more-nginx-module">headers-more-nginx-module</a></li>
@@ -109,7 +109,7 @@ Nginx current stable release : <strong>v1.24.0</strong></p> with Cloudflare HTTP
 <li>18.x (Obsidian)</li>
 </ul>
 <h3>### HTTP/3 QUIC</h3>
-<p><strong>Full support of HTTP/3 QUIC is only available with Nginx mainline release and compiled with LibreSSL**</strong>. More information [here](https://nginx.org/en/docs/http/ngx_http_v3_module.html).</p>
+<p><strong>Full support of HTTP/3 QUIC is only available with LibreSSL**</strong>. More information [here](https://nginx.org/en/docs/http/ngx_http_v3_module.html).</p>
 
 <hr />
 <h2 id="usage">Usage</h2>
@@ -133,7 +133,7 @@ sudo bash nginx-build.sh
 <pre><code class="language-bash">bash &lt;(wget -O - vtb.cx/nginx-ee || curl -sL vtb.cx/nginx-ee) --interactive
 </code></pre>
 <h3 id="custom-installation">Custom installation</h3>
-<p>Example : Nginx stable release with HTTP/2 HPACK with naxsi</p>
+<p>Example : Nginx stable release with HTTP/3 with naxsi</p>
 <pre><code class="language-bash">bash &lt;(wget -O - vtb.cx/nginx-ee || curl -sL vtb.cx/nginx-ee) --stable --naxsi
 </code></pre>
 <h4 id="options-available">Options available</h4>

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,19 +42,18 @@ Automated Nginx compilation from sources with additional modules support
 <li>Nginx built-in modules selection</li>
 <li>Nginx Third-party modules selection</li>
 <li>Dynamic modules support</li>
+<li>HTTP/3 QUIC Support with Mainline Release</li>
 <li>Brotli Support</li>
 <li>TLS v1.3 support (Final)</li>
 <li>OpenSSL or LibreSSL</li>
-<li>Cloudflare HPACK</li>
 <li>Cloudflare zlib</li>
 <li>Automated nginx updates cronjob</li>
-<li>Compilation with GCC-7/9</li>
 <li>Security hardening and performance optimization enabled with proper GCC flags</li>
 </ul>
 <hr />
 <h2 id="additional-third-party-modules">Additional Third-party modules</h2>
-<p>Nginx current mainline release : <strong>v1.23.4</strong>
-Nginx current stable release : <strong>v1.24.0</strong></p>
+<p>Nginx current mainline release : <strong>v1.25.5</strong> with HTTP/3 QUIC
+Nginx current stable release : <strong>v1.24.0</strong></p> with Cloudflare HTTP/2 HPACK
 <ul>
 <li><a href="https://github.com/FRiCKLE/ngx_cache_purge">ngx_cache_purge</a></li>
 <li><a href="https://github.com/openresty/headers-more-nginx-module">headers-more-nginx-module</a></li>
@@ -77,7 +76,7 @@ Nginx current stable release : <strong>v1.24.0</strong></p>
 </ul>
 <p>Optional modules :</p>
 <ul>
-<li><a href="https://github.com/nbs-system/naxsi">naxsi WAF</a></li>
+<li><a href="https://github.com/wargio/naxsi">naxsi WAF</a></li>
 <li><a href="https://github.com/arut/nginx-rtmp-module">nginx-rtmp-module</a></li>
 </ul>
 <hr />
@@ -109,12 +108,15 @@ Nginx current stable release : <strong>v1.24.0</strong></p>
 <li>17.9.x</li>
 <li>18.x (Obsidian)</li>
 </ul>
+<h3>### HTTP/3 QUIC</h3>
+<p><strong>Full support of HTTP/3 QUIC is only available with Nginx mainline release and compiled with LibreSSL**</strong>. More information [here](https://nginx.org/en/docs/http/ngx_http_v3_module.html).</p>
+
 <hr />
 <h2 id="usage">Usage</h2>
 <h3 id="one-step-automated-install">One-Step Automated Install</h3>
 <p><strong>Default settings</strong> :</p>
 <ul>
-<li>mainline release</li>
+<li>mainline release with HTTP/3</li>
 <li>openssl from system lib</li>
 <li>without naxsi</li>
 <li>without rtmp</li>
@@ -131,7 +133,7 @@ sudo bash nginx-build.sh
 <pre><code class="language-bash">bash &lt;(wget -O - vtb.cx/nginx-ee || curl -sL vtb.cx/nginx-ee) --interactive
 </code></pre>
 <h3 id="custom-installation">Custom installation</h3>
-<p>Example : Nginx stable release with naxsi</p>
+<p>Example : Nginx stable release with HTTP/2 HPACK with naxsi</p>
 <pre><code class="language-bash">bash &lt;(wget -O - vtb.cx/nginx-ee || curl -sL vtb.cx/nginx-ee) --stable --naxsi
 </code></pre>
 <h4 id="options-available">Options available</h4>
@@ -177,6 +179,7 @@ Feel free to use the custom Nginx package built for WordOps and available on <a 
 <li class="task-list-item"><input disabled="disabled" type="checkbox" checked="checked" /> Add openssl release choice</li>
 <li class="task-list-item"><input disabled="disabled" type="checkbox" checked="checked" /> Add more compilation presets</li>
 <li class="task-list-item"><input disabled="disabled" type="checkbox" checked="checked" /> Add support for LibreSSL</li>
+<li class="task-list-item"><input disabled="disabled" type="checkbox" checked="checked" /> Add support for HTTP/3 QUIC</li>
 </ul>
 <hr />
 

--- a/etc/nginx/nginx.conf
+++ b/etc/nginx/nginx.conf
@@ -36,7 +36,7 @@ http
 
     server_tokens off;
     reset_timedout_connection on;
-    add_header X-Powered-By "Nginx-ee v3.5.2 - Optimized by VirtuBox";
+    add_header X-Powered-By "Nginx-ee v3.8.1 - Optimized by VirtuBox";
     add_header rt-Fastcgi-Cache $upstream_cache_status;
 
     # Limit Request

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -529,12 +529,12 @@ _download_modules() {
     echo -ne '       Downloading additionals modules        [..]\r'
     if {
         echo "### downloading additionals modules ###"
-        MODULES='FRiCKLE/ngx_cache_purge openresty/memc-nginx-module
+        MODULES='openresty/memc-nginx-module
         simpl/ngx_devel_kit openresty/headers-more-nginx-module
         openresty/echo-nginx-module yaoweibin/ngx_http_substitutions_filter_module
         openresty/redis2-nginx-module openresty/srcache-nginx-module
         openresty/set-misc-nginx-module sto/ngx_http_auth_pam_module
-        vozlt/nginx-module-vts centminmod/ngx_http_redis'
+        vozlt/nginx-module-vts centminmod/ngx_http_redis nginx-modules/ngx_cache_purge'
         for MODULE in $MODULES; do
             _gitget "$MODULE"
         done
@@ -627,67 +627,6 @@ _download_brotli() {
         echo -ne '\n'
     else
         echo -e "       Downloading brotli      [${CRED}FAIL${CEND}]"
-        echo -e '\n      Please look at /tmp/nginx-ee.log\n'
-        exit 1
-    fi
-
-}
-
-##################################
-# Download and patch OpenSSL
-##################################
-
-_download_openssl_dev() {
-
-    cd "$DIR_SRC" || exit 1
-    if {
-        echo -ne '       Downloading openssl                    [..]\r'
-
-        {
-            if [ -d /usr/local/src/openssl ]; then
-                if [ ! -d /usr/local/src/openssl/.git ]; then
-                    echo "### removing openssl extracted archive ###"
-                    rm -rf /usr/local/src/openssl
-                    echo "### cloning openssl ###"
-                    git clone --depth=50 https://github.com/openssl/openssl.git /usr/local/src/openssl
-                    cd /usr/local/src/openssl || exit 1
-                    echo "### git checkout commit ###"
-                    #git checkout $OPENSSL_COMMIT
-                else
-                    cd /usr/local/src/openssl || exit 1
-                    echo "### reset openssl to master and clean patches ###"
-                    git fetch --all
-                    git reset --hard origin/master
-                    git clean -f
-                    #git checkout $OPENSSL_COMMIT
-                fi
-            else
-                echo "### cloning openssl ###"
-                git clone --depth=50 https://github.com/openssl/openssl.git /usr/local/src/openssl
-                cd /usr/local/src/openssl || exit 1
-                echo "### git checkout commit ###"
-                #git checkout $OPENSSL_COMMIT
-            fi
-        } >>/tmp/nginx-ee.log 2>&1
-
-        {
-            if [ -d /usr/local/src/openssl-patch/.git ]; then
-                cd /usr/local/src/openssl-patch || exit 1
-                git pull origin master
-            else
-                git clone --depth=50 https://github.com/VirtuBox/openssl-patch.git /usr/local/src/openssl-patch
-            fi
-            cd /usr/local/src/openssl || exit 1
-            # apply openssl ciphers patch
-            echo "### openssl ciphers patch ###"
-            #patch -p1 <../openssl-patch/openssl-equal-3.0.0-dev_ciphers.patch
-        } >>/tmp/nginx-ee.log 2>&1
-
-    }; then
-        echo -ne "       Downloading openssl                    [${CGREEN}OK${CEND}]\\r"
-        echo -ne '\n'
-    else
-        echo -e "       Downloading openssl      [${CRED}FAIL${CEND}]"
         echo -e '\n      Please look at /tmp/nginx-ee.log\n'
         exit 1
     fi
@@ -1125,13 +1064,7 @@ fi
 if [ "$LIBRESSL" = "y" ]; then
     _download_libressl
 else
-    if [ "$OPENSSL_LIB" = "2" ]; then
-        _download_openssl_dev
-    elif [ "$OPENSSL_LIB" = "3" ]; then
-        sleep 1
-    else
-        sleep 1
-    fi
+    sleep 1
 fi
 _download_nginx
 _patch_nginx

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -7,7 +7,7 @@
 # Copyright (c) 2019-2024 VirtuBox <contact@virtubox.net>
 # This script is licensed under M.I.T
 # -------------------------------------------------------------------------
-# Version 3.9.0 - 2024-04-23
+# Version 3.8.0 - 2024-04-23
 # -------------------------------------------------------------------------
 
 ##################################
@@ -26,19 +26,17 @@ _help() {
     echo " -------------------------------------------------------------------- "
     echo ""
     echo "Usage: ./nginx-ee <options> [modules]"
-    echo "By default, Nginx-ee will compile the latest Nginx mainline release without Pagespeed, Naxsi or RTMP module"
+    echo "By default, Nginx-ee will compile the latest Nginx mainline release with HTTP/3 and without Naxsi or RTMP module"
     echo "  Options:"
     echo "       -h, --help ..... display this help"
     echo "       -i, --interactive ....... interactive installation"
     echo "       --stable ..... Nginx stable release"
-    echo "       --full ..... Nginx mainline release with Nasxi and RTMP module"
+    echo "       --full ..... Nginx with Nasxi and RTMP module"
     echo "       --dynamic ..... Compile Nginx modules as dynamic"
     echo "       --noconf ..... Compile Nginx without any configuring. Useful when you use devops tools like ansible."
     echo "  Modules:"
     echo "       --naxsi ..... Naxsi WAF module"
     echo "       --rtmp ..... RTMP video streaming module"
-    echo "       --openssl-dev ..... Compile Nginx with OpenSSL 3.0.0-dev"
-    echo "       --openssl-system ..... Compile Nginx with OpenSSL from system lib"
     echo "       --libressl ..... Compile Nginx with LibreSSL"
     echo ""
     return 0
@@ -325,10 +323,20 @@ echo ""
 echo -e "  - Nginx release : $NGINX_VER"
 [ -n "$OPENSSL_VALID" ] && {
     echo -e "  - OPENSSL : $OPENSSL_VER"
+    if [ "$NGINX_RELEASE" = "2" ]; then
+        echo -e "  - HTTP/2 HPACK : YES"
+    else
+        echo -e "  - with HTTP/3 : YES"
+    fi
+
 }
 [ -n "$LIBRESSL_VALID" ] && {
     echo -e "  - LIBRESSL : $LIBRESSL_VALID"
-    echo -e "  - HTTP/3 QUIC : $QUIC_VALID"
+    if [ "$NGINX_RELEASE" = "2" ]; then
+        echo -e "  - HTTP/2 HPACK : YES"
+    else
+        echo -e "  - HTTP/3 QUIC : YES"
+    fi
 }
 echo "  - Dynamic modules $DYNAMIC_MODULES_VALID"
 echo "  - Naxsi : $NAXSI_VALID"


### PR DESCRIPTION
- Nginx stable release bumped to 1.26.0
- HTTP/3 now available on both mainline and stable release
- Always download latest zlib library if zlib-cf not supported
- Always download the latest libressl release
- HTTP/2 HPACK removed
