### PR TITLE
Fixed zlib installation

### DIFF
--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -577,7 +577,6 @@ _download_zlib() {
             echo "### downloading zlib latest ###"
             rm -rf zlib
             curl -sL http://zlib.net/current/zlib.tar.gz | /bin/tar zxf - -C "$DIR_SRC"
-            mv zlib-1.2.13 zlib
         fi
 
     } >>/tmp/nginx-ee.log 2>&1; then

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -575,8 +575,9 @@ _download_zlib() {
             ./configure --prefix=/usr/local/zlib-cf
         else
             echo "### downloading zlib latest ###"
-            rm -rf zlib
+            rm -rf zlib-*
             curl -sL http://zlib.net/current/zlib.tar.gz | /bin/tar zxf - -C "$DIR_SRC"
+            mv zlib-* zlib
         fi
 
     } >>/tmp/nginx-ee.log 2>&1; then

--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -575,9 +575,9 @@ _download_zlib() {
             ./configure --prefix=/usr/local/zlib-cf
         else
             echo "### downloading zlib latest ###"
-            rm -rf zlib-*
+            rm -rf zlib*
             curl -sL http://zlib.net/current/zlib.tar.gz | /bin/tar zxf - -C "$DIR_SRC"
-            mv zlib-* zlib
+            mv zlib* zlib
         fi
 
     } >>/tmp/nginx-ee.log 2>&1; then


### PR DESCRIPTION
On aarch64, zlib installation fails, because of a leftover in the code.