### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -13,6 +13,9 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   my_job:
     name: test Nginx-ee


### PR DESCRIPTION
Potential fix for [https://github.com/VirtuBox/nginx-ee/security/code-scanning/1](https://github.com/VirtuBox/nginx-ee/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow does not appear to require write access to the repository or other GitHub features, we will set `contents: read` as the minimal required permission. This ensures the workflow has only read access to the repository contents and no unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
